### PR TITLE
feat: Display age in human-readable format

### DIFF
--- a/scripts/age_calculator.js
+++ b/scripts/age_calculator.js
@@ -9,6 +9,29 @@ document.addEventListener('DOMContentLoaded', function() {
   }
 });
 
+function formatHumanReadable(number) {
+  if (number < 1000) {
+    // For numbers less than 1000, return as is, or with one decimal if not whole
+    return Number.isInteger(number) ? number.toString() : number.toFixed(1);
+  }
+
+  const suffixes = ['', 'K', 'M', 'B']; // K for thousands, M for millions, B for billions
+  const i = Math.floor(Math.log10(Math.abs(number)) / 3); // Determine the suffix index
+
+  if (i >= suffixes.length) { // Handle numbers larger than supported suffixes (e.g., trillions)
+    // Fallback: return in scientific notation or handle as per requirements for very large numbers
+    return number.toExponential(1); 
+  }
+
+  const scaledNumber = number / Math.pow(1000, i);
+  
+  // Check if the scaled number is an integer or needs a decimal place
+  // Aim for one decimal place if not an exact multiple
+  const formattedNumber = (scaledNumber % 1 === 0) ? scaledNumber.toFixed(0) : scaledNumber.toFixed(1);
+
+  return formattedNumber + suffixes[i];
+}
+
 function calculateAndDisplayAge() {
   const birthdateInput = document.getElementById('birthdate');
   const birthdateValue = birthdateInput.value;
@@ -63,10 +86,10 @@ function calculateAndDisplayAge() {
   const totalMonths = totalDays / averageDaysInMonth;
 
   // Update the span elements with the calculated values
-  ageSecondsSpan.textContent = totalSeconds.toFixed(0);
-  ageMinutesSpan.textContent = totalMinutes.toFixed(0);
-  ageHoursSpan.textContent = totalHours.toFixed(0);
-  ageDaysSpan.textContent = totalDays.toFixed(0);
-  ageWeeksSpan.textContent = totalWeeks.toFixed(1); // Show one decimal for weeks
-  ageMonthsSpan.textContent = totalMonths.toFixed(1); // Show one decimal for months
+  ageSecondsSpan.textContent = formatHumanReadable(totalSeconds);
+  ageMinutesSpan.textContent = formatHumanReadable(totalMinutes);
+  ageHoursSpan.textContent = formatHumanReadable(totalHours);
+  ageDaysSpan.textContent = formatHumanReadable(totalDays);
+  ageWeeksSpan.textContent = formatHumanReadable(totalWeeks);
+  ageMonthsSpan.textContent = formatHumanReadable(totalMonths);
 }

--- a/scripts/test_age_calculator.html
+++ b/scripts/test_age_calculator.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width">
+  <title>QUnit Test Suite for age_calculator.js</title>
+  <link rel="stylesheet" href="https://code.jquery.com/qunit/qunit-2.20.0.css">
+</head>
+<body>
+  <div id="qunit"></div>
+  <div id="qunit-fixture"></div>
+  <script src="https://code.jquery.com/qunit/qunit-2.20.0.js"></script>
+  <script src="age_calculator.js"></script>
+  <script>
+    QUnit.module('formatHumanReadable', function() {
+      QUnit.test('should format numbers less than 1000 correctly', function(assert) {
+        assert.strictEqual(formatHumanReadable(0), "0", "Test with 0");
+        assert.strictEqual(formatHumanReadable(123), "123", "Test with 123");
+        assert.strictEqual(formatHumanReadable(999), "999", "Test with 999");
+        assert.strictEqual(formatHumanReadable(123.456), "123.5", "Test with 123.456, rounds to 123.5");
+        assert.strictEqual(formatHumanReadable(12.3), "12.3", "Test with 12.3");
+        assert.strictEqual(formatHumanReadable(0.123), "0.1", "Test with 0.123, rounds to 0.1");
+
+      });
+
+      QUnit.test('should format numbers in thousands (K) correctly', function(assert) {
+        assert.strictEqual(formatHumanReadable(1000), "1K", "Test with 1000");
+        assert.strictEqual(formatHumanReadable(1230), "1.2K", "Test with 1230, rounds to 1.2K");
+        assert.strictEqual(formatHumanReadable(1250), "1.3K", "Test with 1250, rounds to 1.3K");
+        assert.strictEqual(formatHumanReadable(2000), "2K", "Test with 2000");
+        assert.strictEqual(formatHumanReadable(999900), "999.9K", "Test with 999900, rounds to 999.9K");
+        assert.strictEqual(formatHumanReadable(1990), "2K", "Test with 1990, rounds to 2K");
+      });
+
+      QUnit.test('should format numbers in millions (M) correctly', function(assert) {
+        assert.strictEqual(formatHumanReadable(1000000), "1M", "Test with 1,000,000");
+        assert.strictEqual(formatHumanReadable(1230000), "1.2M", "Test with 1,230,000, rounds to 1.2M");
+        assert.strictEqual(formatHumanReadable(1250000), "1.3M", "Test with 1,250,000, rounds to 1.3M");
+        assert.strictEqual(formatHumanReadable(999900000), "999.9M", "Test with 999,900,000, rounds to 999.9M");
+      });
+
+      QUnit.test('should format numbers in billions (B) correctly', function(assert) {
+        assert.strictEqual(formatHumanReadable(1000000000), "1B", "Test with 1,000,000,000");
+        assert.strictEqual(formatHumanReadable(1230000000), "1.2B", "Test with 1,230,000,000, rounds to 1.2B");
+        assert.strictEqual(formatHumanReadable(1250000000), "1.3B", "Test with 1,250,000,000, rounds to 1.3B");
+        assert.strictEqual(formatHumanReadable(999900000000), "999.9B", "Test with 999,900,000,000, rounds to 999.9B");
+      });
+
+      QUnit.test('should handle very large numbers (fallback to exponential)', function(assert) {
+        assert.strictEqual(formatHumanReadable(1000000000000000), "1.0e+15", "Test with 1 Quadrillion (fallback)");
+      });
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
Implemented a new JavaScript function `formatHumanReadable` to convert large numbers into a more user-friendly format (e.g., 1.2B, 100K, 5M).

The `calculateAndDisplayAge` function in `scripts/age_calculator.js` has been updated to use this new formatting function for displaying age in seconds, minutes, hours, days, weeks, and months.

Unit tests for `formatHumanReadable` have been added in `scripts/test_age_calculator.html` using the QUnit framework, covering various magnitudes and edge cases.