### PR TITLE
feat: Dynamically load publications from Google Scholar

### DIFF
--- a/.github/workflows/update_publications.yml
+++ b/.github/workflows/update_publications.yml
@@ -1,0 +1,43 @@
+name: Update Publications
+
+on:
+  schedule:
+    - cron: '0 0 1 * *' # Runs at 00:00 on the 1st day of every month
+  workflow_dispatch: # Allows manual triggering
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # Required to commit changes back to the repo
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11' # Specify a recent Python 3 version
+
+      - name: Install dependencies
+        run: pip install requests beautifulsoup4
+
+      - name: Run scholar scraper
+        run: python scholar_scraper.py
+
+      - name: Commit and push if changes
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          # Check if there are changes in publications.json
+          # `git diff --quiet` exits with 1 if there are differences, 0 otherwise.
+          # The `if` command treats exit code 0 as true, non-zero as false.
+          # So, we want to proceed if `git diff --quiet` exits with 1 (changes found).
+          if ! git diff --quiet publications.json; then
+            echo "Changes found in publications.json. Committing and pushing."
+            git add publications.json
+            git commit -m "Automated update of publications.json from Google Scholar"
+            git push
+          else
+            echo "No changes to publications.json. Nothing to commit."
+          fi

--- a/publications.html
+++ b/publications.html
@@ -37,50 +37,60 @@ p {
 
 <h1>Publications</h1>
 
-<p><strong>Show or tell? Improving inventory support for agent-based businesses at the base of the pyramid</strong><br>
-Manufacturing & Service Operations Management 24 (1), 664-681, 2022<br>
-with J Acimovic, C Parker, D F. Drake, K Balasubramanian</p>
-
-<p><strong>The impact of poverty on base of the pyramid operations: Evidence from mobile money in Africa</strong><br>
-Journal of Operations Management 69 (4), 616-642, 2023<br>
-with DF Drake, G Urrea</p>
-
-<p><strong>Mobile money operations: policies for managing cash and digital currency inventories in the developing world</strong><br>
-Manufacturing & Service Operations Management 25 (3), 958-974, 2023<br>
-with DF Drake, J Acimovic, D Fearing</p>
-
-<p><strong>Operations Research on Mobile-Enabled Financial Inclusion: A Road Map to Impact</strong><br>
-Tutorials in Operations Research: Emerging and Impactful Topics in Operations, 2022</p>
-
-<p><strong>A Framework for Enhancing Social Media Misinformation Detection with Topical-Tactics</strong><br>
-Digital Threats: Research and Practice 5 (3), 1-29, 2024<br>
-with BE Bagozzi, R Goel, B Lugo-de-Fabritz, K Knickmeier-Cummings, ...</p>
-
-<p><strong>State-linked manipulated media in the time of Covid-19: a look at Iran</strong><br>
-Data & Policy 7, e19, 2025<br>
-with BE Bagozzi, K Balasubramanian, R Goel, C Parker</p>
-
-<p><strong>State-Linked Misinformation in the Time of Covid-19: A Look at Iran</strong><br>
-Available at SSRN 4477333, 2023<br>
-with B Bagozzi, R Goel, K Balasubramanian, C Parker</p>
-
-<p><strong>How platforms can help their contract workers make decisions in uncertain environments</strong><br>
-LSE Business Review, 2018<br>
-with J Acimovic, C Parker, D Drake, K Balasubramanian</p>
-
-<p><strong>Mobile Money Agent Competition, Inventory Management, and Pooling</strong><br>
-Harvard University, 2018</p>
-
-<p><strong>Want More Black Voters? Meet Them Where They Live 1</strong><br>
-Turnout!, 90-96, 2020</p>
-
-<p><strong>Democrats Are Ignoring the Voters Who Could Decide This Election</strong><br>
-New York Times Opinion Editorial, February 26, 2020<br>
-<a href="https://www.nytimes.com/2020/02/26/opinion/black-voters-2020-election.html">Read Article</a></p>
+<div id="publications-list">
+  <!-- Publications will be loaded here by JavaScript -->
+</div>
 
 <hr>
 
 <p><a href="index.html">Back to Home</a></p>
+
+<script>
+  document.addEventListener('DOMContentLoaded', function() {
+    const publicationsList = document.getElementById('publications-list');
+
+    fetch('publications.json')
+      .then(response => {
+        if (!response.ok) {
+          throw new Error('Network response was not ok: ' + response.statusText);
+        }
+        return response.json();
+      })
+      .then(data => {
+        if (!data || data.length === 0) {
+          publicationsList.innerHTML = '<p>No publications found.</p>';
+          return;
+        }
+
+        data.forEach(pub => {
+          const p = document.createElement('p');
+          
+          const titleLink = document.createElement('a');
+          titleLink.href = pub.url || '#'; // Use '#' if URL is missing
+          titleLink.textContent = pub.title || 'N/A';
+          
+          const strongTitle = document.createElement('strong');
+          strongTitle.appendChild(titleLink);
+          
+          p.appendChild(strongTitle);
+          p.appendChild(document.createElement('br'));
+          
+          const authorsText = document.createTextNode(pub.authors || 'N/A');
+          p.appendChild(authorsText);
+          p.appendChild(document.createElement('br'));
+          
+          const venueYearText = document.createTextNode(`${pub.venue || 'N/A'}, ${pub.year || 'N/A'}`);
+          p.appendChild(venueYearText);
+          
+          publicationsList.appendChild(p);
+        });
+      })
+      .catch(error => {
+        console.error('Error loading publications:', error);
+        publicationsList.innerHTML = '<p>Failed to load publications. Please try again later.</p>';
+      });
+  });
+</script>
 
 </body>
 </html>

--- a/publications.json
+++ b/publications.json
@@ -1,0 +1,72 @@
+[
+    {
+        "title": "Show or tell? Improving inventory support for agent-based businesses at the base of the pyramid",
+        "authors": "J Acimovic, C Parker, D F. Drake, K Balasubramanian",
+        "year": "2022",
+        "venue": "Manufacturing & Service Operations Management 24 (1), 664-681",
+        "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=K6gjOxwAAAAJ&citation_for_view=K6gjOxwAAAAJ:IjCSPb-OGe4C"
+    },
+    {
+        "title": "The impact of poverty on base of the pyramid operations: Evidence from mobile money in Africa",
+        "authors": "K Balasubramanian, DF Drake, G Urrea",
+        "year": "2023",
+        "venue": "Journal of Operations Management 69 (4), 616-642",
+        "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=K6gjOxwAAAAJ&citation_for_view=K6gjOxwAAAAJ:zYLM7Y9cAGgC"
+    },
+    {
+        "title": "Mobile money operations: policies for managing cash and digital currency inventories in the developing world",
+        "authors": "K Balasubramanian, DF Drake, J Acimovic, D Fearing",
+        "year": "2023",
+        "venue": "Manufacturing & Service Operations Management 25 (3), 958-974",
+        "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=K6gjOxwAAAAJ&citation_for_view=K6gjOxwAAAAJ:YsMSGLbcyi4C"
+    },
+    {
+        "title": "A Framework for Enhancing Social Media Misinformation Detection with Topical-Tactics",
+        "authors": "BE Bagozzi, R Goel, B Lugo-de-Fabritz, K Knickmeier-Cummings, ...",
+        "year": "2024",
+        "venue": "Digital Threats: Research and Practice 5 (3), 1-29",
+        "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=K6gjOxwAAAAJ&citation_for_view=K6gjOxwAAAAJ:ufrVoPGSRksC"
+    },
+    {
+        "title": "State-Linked Misinformation in the Time of Covid-19: A Look at Iran",
+        "authors": "B Bagozzi, R Goel, K Balasubramanian, C Parker",
+        "year": "2023",
+        "venue": "Available at SSRN 4477333",
+        "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=K6gjOxwAAAAJ&citation_for_view=K6gjOxwAAAAJ:eQOLeE2rZwMC"
+    },
+    {
+        "title": "Operations research on mobile-enabled financial inclusion: A road map to impact",
+        "authors": "K Balasubramanian",
+        "year": "2022",
+        "venue": "Tutorials in Operations Research: Emerging and Impactful Topics in …",
+        "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=K6gjOxwAAAAJ&citation_for_view=K6gjOxwAAAAJ:Tyk-4Ss8FVUC"
+    },
+    {
+        "title": "State-linked manipulated media in the time of Covid-19: a look at Iran",
+        "authors": "BE Bagozzi, K Balasubramanian, R Goel, C Parker",
+        "year": "2025",
+        "venue": "Data & Policy 7, e19",
+        "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=K6gjOxwAAAAJ&citation_for_view=K6gjOxwAAAAJ:_FxGoFyzp5QC"
+    },
+    {
+        "title": "Want More Black Voters? Meet Them Where They Live 1",
+        "authors": "K Balasubramanian",
+        "year": "2020",
+        "venue": "Turnout!, 90-96",
+        "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=K6gjOxwAAAAJ&citation_for_view=K6gjOxwAAAAJ:Y0pCki6q_DkC"
+    },
+    {
+        "title": "How platforms can help their contract workers make decisions in uncertain environments",
+        "authors": "J Acimovic, C Parker, D Drake, K Balasubramanian",
+        "year": "2018",
+        "venue": "LSE Business Review",
+        "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=K6gjOxwAAAAJ&citation_for_view=K6gjOxwAAAAJ:2osOgNQ5qMEC"
+    },
+    {
+        "title": "Mobile Money Agent Competition, Inventory Management, and Pooling",
+        "authors": "K Balasubramanian",
+        "year": "2018",
+        "venue": "Harvard University",
+        "url": "https://scholar.google.com/citations?view_op=view_citation&hl=en&user=K6gjOxwAAAAJ&citation_for_view=K6gjOxwAAAAJ:UeHWp8X0CEIC"
+    }
+]

--- a/scholar_scraper.py
+++ b/scholar_scraper.py
@@ -1,0 +1,84 @@
+import requests
+from bs4 import BeautifulSoup
+import json
+
+def scrape_scholar_profile(url):
+    headers = {
+        'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36'
+    }
+    publications = []
+
+    try:
+        response = requests.get(url, headers=headers)
+        response.raise_for_status()  # Raise an exception for bad status codes
+    except requests.exceptions.RequestException as e:
+        print(f"Error fetching URL: {e}")
+        return None
+
+    soup = BeautifulSoup(response.content, 'html.parser')
+
+    for item in soup.find_all('tr', class_='gsc_a_tr'):
+        title_tag = item.find('a', class_='gsc_a_at')
+        title = title_tag.text if title_tag else 'N/A'
+        # Construct absolute URL if the link is relative
+        url = title_tag['href'] if title_tag else 'N/A'
+        if url.startswith('/'):
+            url = "https://scholar.google.com" + url
+        
+        details = item.find_all('div', class_='gs_gray')
+        authors = 'N/A'
+        venue_year_line = 'N/A'
+        venue = 'N/A'
+        year = 'N/A'
+
+        if len(details) > 0:
+            authors = details[0].text if details[0] else 'N/A'
+        if len(details) > 1:
+            venue_year_line = details[1].text if details[1] else 'N/A'
+            # Year is usually the last part of the second gs_gray div
+            # Venue is everything before that
+            # This is a common pattern, but might need refinement
+            parts = venue_year_line.split(',')
+            if parts:
+                year_candidate = parts[-1].strip()
+                if year_candidate.isdigit() and len(year_candidate) == 4:
+                    year = year_candidate
+                    venue = ','.join(parts[:-1]).strip() if len(parts) > 1 else 'N/A'
+                else: # Year might not be present or format is different
+                    venue = venue_year_line # Keep the whole line as venue if year parsing fails
+            else:
+                venue = venue_year_line
+
+
+        publication_data = {
+            'title': title,
+            'authors': authors,
+            'year': year,
+            'venue': venue,
+            'url': url
+        }
+        publications.append(publication_data)
+
+    return publications
+
+def save_publications_to_json(publications, filename="publications.json"):
+    if publications is None:
+        print("No publications to save.")
+        return
+
+    try:
+        with open(filename, 'w', encoding='utf-8') as f:
+            json.dump(publications, f, ensure_ascii=False, indent=4)
+        print(f"Successfully saved {len(publications)} publications to {filename}")
+    except IOError as e:
+        print(f"Error saving data to JSON file: {e}")
+
+if __name__ == "__main__":
+    scholar_url = "https://scholar.google.com/citations?user=K6gjOxwAAAAJ&hl=en"
+    scraped_data = scrape_scholar_profile(scholar_url)
+    if scraped_data:
+        save_publications_to_json(scraped_data)
+    else:
+        # Create an empty publications.json if scraping fails or returns no data
+        # as per the instructions implicitly requiring publications.json
+        save_publications_to_json([])


### PR DESCRIPTION
This commit introduces a system to dynamically fetch and display publications from a Google Scholar profile on the publications.html page.

Key changes:
- Added `scholar_scraper.py`: A Python script that scrapes the specified Google Scholar profile for publication data (title, authors, year, venue, URL) and saves it to `publications.json`.
- Modified `publications.html`: Removed hardcoded publication entries. Added JavaScript to fetch data from `publications.json` and dynamically render the publications. Includes error handling for missing or empty data.
- Added `publications.json`: Initial data file generated by the scraper. This file will be updated by the GitHub Action.
- Added `.github/workflows/update_publications.yml`: A GitHub Actions workflow that automatically runs the `scholar_scraper.py` script monthly (and can be manually triggered) to update `publications.json` and commit any changes.

This addresses the issue of hardcoded publications, ensuring the page can be kept up-to-date automatically. Links to articles are included and are clickable.