### PR TITLE
refactor: Create minimalist home page and separate links page

### DIFF
--- a/links.html
+++ b/links.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-<title>Karthik Balasubramanian</title>
+<title>Links - Karthik Balasubramanian</title>
 <style>
 body {
   background-color: black;
@@ -59,17 +59,27 @@ ul {
 </head>
 <body>
 
-<h1>Karthik Balasubramanian</h1>
-<p>Assistant Professor<br>
-Information Systems and Supply Chain Management<br>
-Howard University School of Business</p>
+<hr>
 
-<a href="links.html" style="text-decoration: none; color: inherit;">
-  <div id="image-container">
-    <img id="profile-image">
-  </div>
-</a>
+<ul>
+<li><a href="about.html">About Me</a></li>
+<li><a href="education.html">Education</a></li>
+<li><a href="expertise.html">Research Expertise</a></li>
+<li><a href="teaching.html">Teaching</a></li>
+<li><a href="publications.html">Publications</a></li>
+<li><a href="contact.html">Contact Information</a></li>
+<li><a href="braille.html">Braille Flashcards</a></li>
+<li><a href="morse_time.html">Morse Code Time</a></li>
+<li><a href="age_calculator.html">Age Calculator</a></li>
+</ul>
 
-<script src="scripts/image_cycler.js"></script>
+<hr>
+
+<p><em>Last updated: May 5, 2025</em></p>
+
+<div class="language">
+<a href="tamil.html">தமிழ் / Tamil</a>
+</div>
+
 </body>
 </html>


### PR DESCRIPTION
Implements a more minimalistic home page displaying only your name, title, and a cycling image. All navigation links have been moved to a new `links.html` page.

Changes:
- `index.html` now only contains your name, title, and image container.
- The image container on `index.html` is now a clickable link that navigates to `links.html`.
- Created `links.html` which now hosts all the main navigation links, maintaining original styling.
- Removed extraneous links and text from `index.html`.