### PR TITLE
feat: Add elegant socials page with icons

### DIFF
--- a/links.html
+++ b/links.html
@@ -29,6 +29,9 @@
                 <a href="contact.html">Contact Information</a>
             </div>
             <div class="link-card">
+                <a href="socials.html">Socials</a>
+            </div>
+            <div class="link-card">
                 <a href="braille.html">Braille Flashcards</a>
             </div>
             <div class="link-card">

--- a/socials.html
+++ b/socials.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Kart Bala - Socials</title>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body class="socials-page">
+  <div class="socials-container">
+    <h1>My Socials</h1>
+    <ul>
+      <li><a href="https://www.linkedin.com/in/kartbala/"><i class="fab fa-linkedin"></i> LinkedIn</a></li>
+      <li><a href="#"><i class="fas fa-cloud"></i> kartbala.bsky.social</a></li>
+      <li><a href="mailto:kartbala@gmail.com"><i class="fas fa-envelope"></i> Email</a></li>
+      <li><a href="https://www.youtube.com/@karthikbalasubramaniankb"><i class="fab fa-youtube"></i> YouTube</a></li>
+      <li><a href="https://scholar.google.com/citations?user=K6gjOxwAAAAJ&hl=en"><i class="fas fa-graduation-cap"></i> Google Scholar</a></li>
+    </ul>
+  </div>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -499,3 +499,70 @@ body.high-contrast .publications-list li {
     color: #FFFFFF;
     border-bottom: 1px solid #FFFFFF;
 }
+
+/* Styles for socials.html */
+body.socials-page {
+    background-color: #ffffff;
+    color: #000000;
+    font-family: Georgia, 'Times New Roman', Times, serif; /* Consistent with site's base font */
+    /* Reset any layout table specific margins/paddings if they were to apply */
+    margin: 0;
+    padding: 0;
+}
+
+.socials-container {
+    margin: 40px auto;
+    text-align: center;
+    max-width: 800px;
+    padding: 20px;
+}
+
+.socials-container h1 {
+    font-family: "Palatino Linotype", Palatino, Palladio, "URW Palladio L", "Book Antiqua", Baskerville, "Bookman Old Style", "Bitstream Charter", "Nimbus Roman No9 L", Garamond, "Apple Garamond", "ITC Garamond Narrow", "New Century Schoolbook", "Century Schoolbook", "Century Schoolbook L", Georgia, serif; /* Consistent H1 font */
+    font-size: 2.2em; /* Consistent H1 size */
+    color: #000000; /* Black for B&W theme */
+    margin-bottom: 40px; /* More space below heading */
+    text-align: center; /* Explicitly center */
+    border-bottom: none; /* Remove any potential inherited border */
+}
+
+.socials-container ul {
+    list-style-type: none;
+    padding: 0;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 20px; /* Space between items */
+}
+
+.socials-container ul li {
+    /* No specific styles needed for li itself if gap is handled by ul */
+}
+
+.socials-container ul li a {
+    color: #000000; /* Black text */
+    text-decoration: none;
+    font-size: 1.2em;
+    display: flex; /* Align icon and text */
+    align-items: center; /* Vertically align icon and text */
+    padding: 12px 18px; /* Button-like padding */
+    border: 1px solid #cccccc; /* Light grey border */
+    border-radius: 5px; /* Rounded corners */
+    transition: background-color 0.3s, color 0.3s, border-color 0.3s; /* Smooth hover transition */
+    font-family: Georgia, 'Times New Roman', Times, serif; /* Ensure link font matches body */
+    border-bottom: 1px solid #cccccc; /* Override default link border from main styles if it applies */
+}
+
+.socials-container ul li a:hover,
+.socials-container ul li a:focus {
+    color: #ffffff; /* White text on hover */
+    background-color: #333333; /* Dark grey background on hover */
+    border-color: #333333; /* Dark grey border on hover */
+    border-bottom: 1px solid #333333; /* Ensure hover border overrides default link border */
+}
+
+.socials-container ul li a i {
+    margin-right: 10px; /* Space between icon and text */
+    font-size: 1.5em; /* Larger icons */
+    color: inherit; /* Icon color matches link text color */
+}


### PR DESCRIPTION
This commit introduces a new `socials.html` page to the website. The page features links to LinkedIn, Bluesky, Email, YouTube, and Google Scholar, each presented with a clean icon from Font Awesome.

Key changes include:
- Creation of `socials.html` with appropriate HTML structure.
- Integration of Font Awesome for icons.
- Styling of the socials page in `styles.css` to match the site's black and white theme, focusing on an elegant and clean presentation. This includes centered content, custom-styled links with hover effects, and responsive flexbox layout for the social media items.
- Addition of a navigation link to the new socials page from `links.html`.

All elements have been structured and styled for clarity and visual appeal, adhering to the existing design principles of the website.