### PR TITLE
Refactor: Isolate Substack form and verify sitemap

### DIFF
--- a/about.html
+++ b/about.html
@@ -47,7 +47,7 @@ hr {
     <div style="text-align: center;">
       <h3>Subscribe to my Newsletter</h3>
       <p>Get the latest updates delivered to your inbox.</p>
-      <iframe src="https://karthikbalasubramanian.substack.com/embed" width="480" height="320" style="border:1px solid #EEE; background:white;" frameborder="0" scrolling="no"></iframe>
+      <p><a href="newsletter.html">Subscribe to my Newsletter</a></p>
     </div>
   </footer>
 </body>

--- a/age_calculator.html
+++ b/age_calculator.html
@@ -89,7 +89,7 @@ p {
     <div style="text-align: center;">
       <h3>Subscribe to my Newsletter</h3>
       <p>Get the latest updates delivered to your inbox.</p>
-      <iframe src="https://karthikbalasubramanian.substack.com/embed" width="480" height="320" style="border:1px solid #EEE; background:white;" frameborder="0" scrolling="no"></iframe>
+      <p><a href="newsletter.html">Subscribe to my Newsletter</a></p>
     </div>
   </footer>
 </body>

--- a/braille.html
+++ b/braille.html
@@ -51,7 +51,7 @@
     <div style="text-align: center;">
       <h3>Subscribe to my Newsletter</h3>
       <p>Get the latest updates delivered to your inbox.</p>
-      <iframe src="https://karthikbalasubramanian.substack.com/embed" width="480" height="320" style="border:1px solid #EEE; background:white;" frameborder="0" scrolling="no"></iframe>
+      <p><a href="newsletter.html">Subscribe to my Newsletter</a></p>
     </div>
   </footer>
 </body>

--- a/contact.html
+++ b/contact.html
@@ -59,7 +59,7 @@ Washington, D.C. 20059</p>
     <div style="text-align: center;">
       <h3>Subscribe to my Newsletter</h3>
       <p>Get the latest updates delivered to your inbox.</p>
-      <iframe src="https://karthikbalasubramanian.substack.com/embed" width="480" height="320" style="border:1px solid #EEE; background:white;" frameborder="0" scrolling="no"></iframe>
+      <p><a href="newsletter.html">Subscribe to my Newsletter</a></p>
     </div>
   </footer>
 </body>

--- a/education.html
+++ b/education.html
@@ -53,7 +53,7 @@ Duke University, 2007</li>
     <div style="text-align: center;">
       <h3>Subscribe to my Newsletter</h3>
       <p>Get the latest updates delivered to your inbox.</p>
-      <iframe src="https://karthikbalasubramanian.substack.com/embed" width="480" height="320" style="border:1px solid #EEE; background:white;" frameborder="0" scrolling="no"></iframe>
+      <p><a href="newsletter.html">Subscribe to my Newsletter</a></p>
     </div>
   </footer>
 </body>

--- a/expertise.html
+++ b/expertise.html
@@ -55,7 +55,7 @@ ul {
     <div style="text-align: center;">
       <h3>Subscribe to my Newsletter</h3>
       <p>Get the latest updates delivered to your inbox.</p>
-      <iframe src="https://karthikbalasubramanian.substack.com/embed" width="480" height="320" style="border:1px solid #EEE; background:white;" frameborder="0" scrolling="no"></iframe>
+      <p><a href="newsletter.html">Subscribe to my Newsletter</a></p>
     </div>
   </footer>
 </body>

--- a/heroes.html
+++ b/heroes.html
@@ -31,7 +31,7 @@
     <div style="text-align: center;">
       <h3>Subscribe to my Newsletter</h3>
       <p>Get the latest updates delivered to your inbox.</p>
-      <iframe src="https://karthikbalasubramanian.substack.com/embed" width="480" height="320" style="border:1px solid #EEE; background:white;" frameborder="0" scrolling="no"></iframe>
+      <p><a href="newsletter.html">Subscribe to my Newsletter</a></p>
     </div>
   </footer>
 </body>

--- a/links.html
+++ b/links.html
@@ -58,7 +58,7 @@
     <div style="text-align: center;">
       <h3>Subscribe to my Newsletter</h3>
       <p>Get the latest updates delivered to your inbox.</p>
-      <iframe src="https://karthikbalasubramanian.substack.com/embed" width="480" height="320" style="border:1px solid #EEE; background:white;" frameborder="0" scrolling="no"></iframe>
+      <p><a href="newsletter.html">Subscribe to my Newsletter</a></p>
     </div>
   </footer>
 </body>

--- a/morse_time.html
+++ b/morse_time.html
@@ -221,7 +221,7 @@
     <div style="text-align: center;">
       <h3>Subscribe to my Newsletter</h3>
       <p>Get the latest updates delivered to your inbox.</p>
-      <iframe src="https://karthikbalasubramanian.substack.com/embed" width="480" height="320" style="border:1px solid #EEE; background:white;" frameborder="0" scrolling="no"></iframe>
+      <p><a href="newsletter.html">Subscribe to my Newsletter</a></p>
     </div>
   </footer>
 </body>

--- a/newsvendor.html
+++ b/newsvendor.html
@@ -122,7 +122,7 @@ hr {
     <div style="text-align: center;">
       <h3>Subscribe to my Newsletter</h3>
       <p>Get the latest updates delivered to your inbox.</p>
-      <iframe src="https://karthikbalasubramanian.substack.com/embed" width="480" height="320" style="border:1px solid #EEE; background:white;" frameborder="0" scrolling="no"></iframe>
+      <p><a href="newsletter.html">Subscribe to my Newsletter</a></p>
     </div>
   </footer>
 </body>

--- a/publications.html
+++ b/publications.html
@@ -97,7 +97,7 @@ p {
     <div style="text-align: center;">
       <h3>Subscribe to my Newsletter</h3>
       <p>Get the latest updates delivered to your inbox.</p>
-      <iframe src="https://karthikbalasubramanian.substack.com/embed" width="480" height="320" style="border:1px solid #EEE; background:white;" frameborder="0" scrolling="no"></iframe>
+      <p><a href="newsletter.html">Subscribe to my Newsletter</a></p>
     </div>
   </footer>
 </body>

--- a/send_money.html
+++ b/send_money.html
@@ -19,7 +19,7 @@
   <div style="text-align: center;">
     <h3>Subscribe to my Newsletter</h3>
     <p>Get the latest updates delivered to your inbox.</p>
-    <iframe src="https://karthikbalasubramanian.substack.com/embed" width="480" height="320" style="border:1px solid #EEE; background:white;" frameborder="0" scrolling="no"></iframe>
+    <p><a href="newsletter.html">Subscribe to my Newsletter</a></p>
   </div>
 </footer>
 

--- a/sitemap.html
+++ b/sitemap.html
@@ -62,7 +62,7 @@
     <div style="text-align: center;">
       <h3>Subscribe to my Newsletter</h3>
       <p>Get the latest updates delivered to your inbox.</p>
-      <iframe src="https://karthikbalasubramanian.substack.com/embed" width="480" height="320" style="border:1px solid #EEE; background:white;" frameborder="0" scrolling="no"></iframe>
+      <p><a href="newsletter.html">Subscribe to my Newsletter</a></p>
     </div>
   </footer>
 </body>

--- a/socials.html
+++ b/socials.html
@@ -20,7 +20,7 @@
     <div style="text-align: center;">
       <h3>Subscribe to my Newsletter</h3>
       <p>Get the latest updates delivered to your inbox.</p>
-      <iframe src="https://karthikbalasubramanian.substack.com/embed" width="480" height="320" style="border:1px solid #EEE; background:white;" frameborder="0" scrolling="no"></iframe>
+      <p><a href="newsletter.html">Subscribe to my Newsletter</a></p>
     </div>
   </footer>
 </body>

--- a/tamil.html
+++ b/tamil.html
@@ -58,7 +58,7 @@ hr {
     <div style="text-align: center;">
       <h3>Subscribe to my Newsletter</h3>
       <p>Get the latest updates delivered to your inbox.</p>
-      <iframe src="https://karthikbalasubramanian.substack.com/embed" width="480" height="320" style="border:1px solid #EEE; background:white;" frameborder="0" scrolling="no"></iframe>
+      <p><a href="newsletter.html">Subscribe to my Newsletter</a></p>
     </div>
   </footer>
 </body>

--- a/teaching.html
+++ b/teaching.html
@@ -54,7 +54,7 @@ ul {
     <div style="text-align: center;">
       <h3>Subscribe to my Newsletter</h3>
       <p>Get the latest updates delivered to your inbox.</p>
-      <iframe src="https://karthikbalasubramanian.substack.com/embed" width="480" height="320" style="border:1px solid #EEE; background:white;" frameborder="0" scrolling="no"></iframe>
+      <p><a href="newsletter.html">Subscribe to my Newsletter</a></p>
     </div>
   </footer>
 </body>


### PR DESCRIPTION
- I removed the embedded Substack subscription iframe from the footers of all HTML pages except for newsletter.html.
- I added a link to newsletter.html in the footer of pages where the iframe was removed, if one didn't already exist.
- I verified that newsletter.html retains the Substack iframe.
- I confirmed that sitemap.html includes a link to send_money.html and no longer contains the Substack iframe in its footer (it now links to newsletter.html).

This change centralizes the newsletter subscription to a dedicated page and ensures the sitemap is accurate.