### PR TITLE
Add Morse Code Translator page

### DIFF
--- a/links.html
+++ b/links.html
@@ -38,6 +38,9 @@
                 <a href="morse_time.html">Morse Code Time</a>
             </div>
             <div class="link-card">
+                <a href="morse_translator.html">Morse Code Translator</a>
+            </div>
+            <div class="link-card">
                 <a href="age_calculator.html">Age Calculator</a>
             </div>
             <div class="link-card">

--- a/morse_translator.html
+++ b/morse_translator.html
@@ -1,0 +1,153 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Morse Code Translator - Karthik Balasubramanian</title>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <style>
+        body {
+            background-color: #111827;
+            color: white;
+            font-family: "Courier New", Courier, monospace;
+            margin: 0;
+            padding: 20px;
+            min-height: 100vh;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+        }
+
+        .container {
+            text-align: center;
+            max-width: 800px;
+            width: 100%;
+        }
+
+        h1 {
+            color: #fbbf24;
+            font-size: 2.5em;
+            margin-bottom: 20px;
+        }
+
+        textarea {
+            width: 100%;
+            padding: 10px;
+            font-family: "Courier New", Courier, monospace;
+            font-size: 1.2em;
+            background: #1f2937;
+            border: 2px solid #6b7280;
+            border-radius: 8px;
+            color: white;
+            resize: vertical;
+        }
+
+        .morse-output {
+            margin: 20px 0;
+            font-size: 1.8em;
+            color: #34d399;
+            letter-spacing: 0.2em;
+            line-height: 1.5;
+        }
+
+        .morse-char {
+            display: inline-block;
+            margin: 0 5px;
+            padding: 4px 8px;
+            background: #374151;
+            border-radius: 5px;
+            border: 1px solid #4b5563;
+        }
+
+        .controls {
+            margin: 20px 0;
+            display: flex;
+            flex-wrap: wrap;
+            justify-content: center;
+            gap: 10px;
+        }
+
+        .control-button {
+            background: #374151;
+            color: white;
+            border: 2px solid #6b7280;
+            padding: 10px 20px;
+            margin: 0 10px;
+            border-radius: 8px;
+            font-family: "Courier New", Courier, monospace;
+            font-size: 1em;
+            cursor: pointer;
+            transition: all 0.3s;
+        }
+
+        .control-button:hover {
+            background: #4b5563;
+            border-color: #9ca3af;
+        }
+
+        .control-button.active {
+            background: #fbbf24;
+            color: #111827;
+            border-color: #f59e0b;
+        }
+
+        .back-link {
+            position: fixed;
+            top: 20px;
+            left: 20px;
+            color: #60a5fa;
+            text-decoration: none;
+            font-size: 1.1em;
+        }
+
+        .back-link:hover {
+            color: #93c5fd;
+        }
+
+        .status {
+            margin-top: 10px;
+            font-size: 0.9em;
+            color: #9ca3af;
+        }
+
+        @media (max-width: 768px) {
+            textarea {
+                font-size: 1em;
+            }
+            .morse-output {
+                font-size: 1.4em;
+            }
+            .control-button {
+                font-size: 0.9em;
+                padding: 8px 16px;
+            }
+        }
+    </style>
+</head>
+<body>
+    <a href="index.html" class="back-link">← Back to Home</a>
+
+    <div class="container">
+        <h1>Morse Code Translator</h1>
+        <textarea id="input-text" rows="3" placeholder="Type your message..."></textarea>
+        <div class="morse-output" id="morse-output"></div>
+
+        <div class="controls">
+            <button class="control-button active" id="sound-toggle">🔊 Sound ON</button>
+            <button class="control-button active" id="vibration-toggle">📳 Vibration ON</button>
+            <button class="control-button" id="play-morse">▶️ Play Morse Code</button>
+        </div>
+        <div class="status" id="status">Ready</div>
+    </div>
+
+    <script src="scripts/morse_translator.js"></script>
+  <footer>
+    <hr>
+    <div style="text-align: center;">
+      <h3>Subscribe to my Newsletter</h3>
+      <p>Get the latest updates delivered to your inbox.</p>
+      <p><a href="newsletter.html">Subscribe to my Newsletter</a></p>
+    </div>
+  </footer>
+</body>
+</html>

--- a/scripts/morse_translator.js
+++ b/scripts/morse_translator.js
@@ -1,0 +1,144 @@
+// Morse Code Translator Script
+// Converts user input text to Morse code and optionally plays it
+
+document.addEventListener('DOMContentLoaded', function () {
+    const morseCode = {
+        'A': '•−', 'B': '−•••', 'C': '−•−•', 'D': '−••', 'E': '•',
+        'F': '••−•', 'G': '−−•', 'H': '••••', 'I': '••', 'J': '•−−−',
+        'K': '−•−', 'L': '•−••', 'M': '−−', 'N': '−•', 'O': '−−−',
+        'P': '•−−•', 'Q': '−−•−', 'R': '•−•', 'S': '•••', 'T': '−',
+        'U': '••−', 'V': '•••−', 'W': '•−−', 'X': '−••−', 'Y': '−•−−',
+        'Z': '−−••',
+        '0': '−−−−−', '1': '•−−−−', '2': '••−−−', '3': '•••−−', '4': '••••−',
+        '5': '•••••', '6': '−••••', '7': '−−•••', '8': '−−−••', '9': '−−−−•'
+    };
+
+    const inputEl = document.getElementById('input-text');
+    const outputEl = document.getElementById('morse-output');
+    const soundToggleEl = document.getElementById('sound-toggle');
+    const vibrationToggleEl = document.getElementById('vibration-toggle');
+    const playEl = document.getElementById('play-morse');
+    const statusEl = document.getElementById('status');
+
+    let soundEnabled = true;
+    let vibrationEnabled = true;
+    let isPlaying = false;
+    let audioContext;
+    let gainNode;
+
+    function initAudio() {
+        try {
+            audioContext = new (window.AudioContext || window.webkitAudioContext)();
+            gainNode = audioContext.createGain();
+            gainNode.connect(audioContext.destination);
+            gainNode.gain.setValueAtTime(0.1, audioContext.currentTime);
+            return true;
+        } catch (e) {
+            console.warn('Audio not supported:', e);
+            return false;
+        }
+    }
+
+    function playBeep(frequency = 600, duration = 100) {
+        if (!soundEnabled || !audioContext) return Promise.resolve();
+        return new Promise((resolve) => {
+            const oscillator = audioContext.createOscillator();
+            const tempGain = audioContext.createGain();
+            oscillator.connect(tempGain);
+            tempGain.connect(gainNode);
+            oscillator.frequency.setValueAtTime(frequency, audioContext.currentTime);
+            oscillator.type = 'sine';
+            tempGain.gain.setValueAtTime(0, audioContext.currentTime);
+            tempGain.gain.linearRampToValueAtTime(0.1, audioContext.currentTime + 0.01);
+            tempGain.gain.exponentialRampToValueAtTime(0.01, audioContext.currentTime + duration / 1000 - 0.01);
+            tempGain.gain.linearRampToValueAtTime(0, audioContext.currentTime + duration / 1000);
+            oscillator.start(audioContext.currentTime);
+            oscillator.stop(audioContext.currentTime + duration / 1000);
+            setTimeout(resolve, duration);
+        });
+    }
+
+    function vibrate(pattern) {
+        if (!vibrationEnabled || !navigator.vibrate) return;
+        if (Array.isArray(pattern)) {
+            navigator.vibrate(pattern);
+        } else if (typeof pattern === 'number') {
+            navigator.vibrate(pattern);
+        }
+    }
+
+    function textToMorse(text) {
+        return text.toUpperCase().split('').map(char => {
+            if (char === ' ') return '/';
+            return morseCode[char] || '?';
+        });
+    }
+
+    function updateOutput() {
+        const text = inputEl.value;
+        const morseArr = textToMorse(text);
+        outputEl.innerHTML = morseArr.map(code => `<span class="morse-char">${code}</span>`).join(' ');
+    }
+
+    async function playMorse() {
+        if (isPlaying) return;
+        isPlaying = true;
+        statusEl.textContent = 'Playing...';
+        const morseArr = textToMorse(inputEl.value);
+        const dotDuration = 100;
+        const dashDuration = 300;
+        const gapDuration = 100;
+        const charGapDuration = 300;
+        const wordGapDuration = 700;
+
+        for (let i = 0; i < morseArr.length; i++) {
+            const code = morseArr[i];
+            if (code === '/') {
+                await new Promise(r => setTimeout(r, wordGapDuration));
+                continue;
+            }
+            for (let j = 0; j < code.length; j++) {
+                const symbol = code[j];
+                if (symbol === '•') {
+                    await playBeep(600, dotDuration);
+                    vibrate(100);
+                } else if (symbol === '−') {
+                    await playBeep(600, dashDuration);
+                    vibrate(300);
+                }
+                if (j < code.length - 1) {
+                    await new Promise(r => setTimeout(r, gapDuration));
+                }
+            }
+            if (i < morseArr.length - 1 && morseArr[i + 1] !== '/') {
+                await new Promise(r => setTimeout(r, charGapDuration));
+            }
+        }
+        isPlaying = false;
+        statusEl.textContent = 'Ready';
+    }
+
+    soundToggleEl.addEventListener('click', function () {
+        soundEnabled = !soundEnabled;
+        this.textContent = soundEnabled ? '🔊 Sound ON' : '🔇 Sound OFF';
+        this.classList.toggle('active', soundEnabled);
+        if (soundEnabled && !audioContext) {
+            initAudio();
+        }
+    });
+
+    vibrationToggleEl.addEventListener('click', function () {
+        vibrationEnabled = !vibrationEnabled;
+        this.textContent = vibrationEnabled ? '📳 Vibration ON' : '📳 Vibration OFF';
+        this.classList.toggle('active', vibrationEnabled);
+    });
+
+    playEl.addEventListener('click', function () {
+        if (!isPlaying) playMorse();
+    });
+
+    inputEl.addEventListener('input', updateOutput);
+
+    initAudio();
+    updateOutput();
+});

--- a/sitemap.html
+++ b/sitemap.html
@@ -52,6 +52,7 @@
         <a href="age_calculator.html">Age Calculator</a>
         <a href="braille.html">Braille Flashcards</a>
         <a href="morse_time.html">Morse Time</a>
+        <a href="morse_translator.html">Morse Code Translator</a>
         <a href="newsvendor.html">Newsvendor Problem</a>
         <a href="images/create_ornament.html">Image Ornament Creator</a>
         <a href="scripts/test_age_calculator.html">Age Calculator Test Page</a>


### PR DESCRIPTION
## Summary
- add new interactive Morse Code Translator page with sound and vibration
- implement translator logic in `scripts/morse_translator.js`
- list the new page in `links.html` and `sitemap.html`

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6841022a7a28832c9167ddb7fd267b7c