### PR TITLE
Improve cellular automata demo and remove ornament generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,7 @@ Despite the vintage aesthetic, the site includes several modern accessibility fe
 ## Setup Instructions
 
 1. Clone the repository
-2. Save the ornament image:
-   - Open `images/create_ornament.html` in a web browser
-   - Right-click the image and save it as `ornament.gif` in the images directory
-3. Deploy to GitHub Pages or your preferred hosting service
+2. Deploy to GitHub Pages or your preferred hosting service
 
 ## Local Development
 

--- a/images/create_ornament.html
+++ b/images/create_ornament.html
@@ -1,8 +1,0 @@
-<!DOCTYPE html>
-<html>
-<body>
-    <h1>Save the image below</h1>
-    <p>Right-click the image below and select "Save Image As" to save it as ornament.gif</p>
-    <img src="data:image/gif;base64,R0lGODlhFAAUAIABAAAAAP///yH5BAEAAAEALAAAAAAUABQAAAIojI+pCnsQyAutvmCz3vz6DzLdIJbGiZ5XqqZs67zwHMdzbd9zjef6DgUAOw==" alt="Ornament">
-</body>
-</html>

--- a/scripts/simple_systems.js
+++ b/scripts/simple_systems.js
@@ -5,6 +5,7 @@ document.addEventListener('DOMContentLoaded', function() {
   const ctx = canvas.getContext('2d');
   const startBtn = document.getElementById('startBtn');
   const ruleInput = document.getElementById('ruleInput');
+  const ruleDesc = document.getElementById('ruleDescription');
 
   const cellSize = 4;
   const cols = Math.floor(canvas.width / cellSize);
@@ -15,13 +16,28 @@ document.addEventListener('DOMContentLoaded', function() {
     return (rule >> index) & 1;
   }
 
+  function describeRule(rule) {
+    const patterns = ['111', '110', '101', '100', '011', '010', '001', '000'];
+    const values = patterns.map((p, i) => (rule >> (7 - i)) & 1);
+    let html = '<table><tr>';
+    patterns.forEach(p => { html += `<th>${p}</th>`; });
+    html += '</tr><tr>';
+    values.forEach(v => { html += `<td>${v}</td>`; });
+    html += '</tr></table>';
+    ruleDesc.innerHTML = html;
+  }
+
   function run(rule) {
     ctx.fillStyle = 'white';
     ctx.clearRect(0, 0, canvas.width, canvas.height);
+    ruleDesc.innerHTML = '';
+    describeRule(rule);
     let current = new Array(cols).fill(0);
     current[Math.floor(cols / 2)] = 1; // start with a single active cell
+    let y = 0;
 
-    for (let y = 0; y < rows; y++) {
+    function step() {
+      if (y >= rows) return;
       for (let x = 0; x < cols; x++) {
         if (current[x]) {
           ctx.fillRect(x * cellSize, y * cellSize, cellSize, cellSize);
@@ -35,7 +51,10 @@ document.addEventListener('DOMContentLoaded', function() {
         next[x] = applyRule(rule, left, center, right);
       }
       current = next;
+      y++;
+      setTimeout(step, 100);
     }
+    step();
   }
 
   startBtn.addEventListener('click', function() {

--- a/simple_systems.html
+++ b/simple_systems.html
@@ -44,11 +44,12 @@
 </head>
 <body>
   <h1>Elementary Cellular Automata</h1>
-  <p>Simple rules can create remarkably complex designs. Enter a rule number and see what patterns emerge.</p>
+  <p>Simple rules can create remarkably complex designs. Enter a rule number and see what patterns emerge. Each rule is defined by how it maps the eight possible combinations of three cells (from <code>111</code> to <code>000</code>) to the next state.</p>
 
   <label for="ruleInput">Rule (0-255):</label>
   <input type="number" id="ruleInput" min="0" max="255" value="30">
   <button id="startBtn">Run</button>
+  <div id="ruleDescription" style="margin-top: 10px;"></div>
 
   <canvas id="caCanvas" width="400" height="400"></canvas>
 

--- a/sitemap.html
+++ b/sitemap.html
@@ -55,7 +55,6 @@
         <a href="morse_time.html">Morse Time</a>
         <a href="morse_translator.html">Morse Code Translator</a>
         <a href="newsvendor.html">Newsvendor Problem</a>
-        <a href="images/create_ornament.html">Image Ornament Creator</a>
         <a href="scripts/test_age_calculator.html">Age Calculator Test Page</a>
         <a href="send_money.html">Send Money</a>
     </div>


### PR DESCRIPTION
## Summary
- slow down cellular automata rendering and show rule table
- remove obsolete ornament generator page
- drop ornament instructions from README

## Testing
- `python -m py_compile scholar_scraper.py`

------
https://chatgpt.com/codex/tasks/task_e_6841c6a35b00832c80cebdf14339658f