### PR TITLE
Add global life expectancy visualization

### DIFF
--- a/life_expectancy_viz.html
+++ b/life_expectancy_viz.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Global Life Expectancy Visualization</title>
+  <style>
+  body {
+    background-color: black;
+    color: white;
+    font-family: "Courier New", Courier, monospace;
+    margin: 40px;
+    line-height: 1.6;
+  }
+  h1 {
+    text-align: center;
+  }
+  a {
+    color: #0000FF;
+    text-decoration: underline;
+  }
+  a:visited {
+    color: #551A8B;
+  }
+  a:hover {
+    color: #0066CC;
+  }
+  #chartContainer {
+    width: 100%;
+    max-width: 800px;
+    margin: 30px auto;
+  }
+  </style>
+</head>
+<body>
+  <h1>Global Life Expectancy Over Time</h1>
+  <p>Select a country to see how life expectancy has changed through the years.</p>
+  <label for="countrySelect">Country:</label>
+  <select id="countrySelect"></select>
+  <div id="chartContainer">
+    <canvas id="lifeChart"></canvas>
+  </div>
+  <p><a href="index.html">Back to Home</a></p>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <script src="scripts/life_expectancy_chart.js" defer></script>
+  <footer>
+    <hr>
+    <div style="text-align: center;">
+      <h3>Subscribe to my Newsletter</h3>
+      <p>Get the latest updates delivered to your inbox.</p>
+      <p><a href="newsletter.html">Subscribe to my Newsletter</a></p>
+    </div>
+  </footer>
+</body>
+</html>

--- a/scripts/life_expectancy_chart.js
+++ b/scripts/life_expectancy_chart.js
@@ -1,0 +1,65 @@
+// Dynamic life expectancy chart using World Bank data
+
+document.addEventListener('DOMContentLoaded', function () {
+  const countries = {
+    USA: 'United States',
+    IND: 'India',
+    CHN: 'China',
+    BRA: 'Brazil',
+    NGA: 'Nigeria'
+  };
+
+  const select = document.getElementById('countrySelect');
+  for (const code in countries) {
+    const opt = document.createElement('option');
+    opt.value = code;
+    opt.textContent = countries[code];
+    select.appendChild(opt);
+  }
+
+  const ctx = document.getElementById('lifeChart').getContext('2d');
+  const chart = new Chart(ctx, {
+    type: 'line',
+    data: { labels: [], datasets: [] },
+    options: {
+      responsive: true,
+      plugins: {
+        legend: { display: false }
+      },
+      scales: {
+        x: { title: { display: true, text: 'Year' } },
+        y: { title: { display: true, text: 'Life Expectancy (years)' } }
+      }
+    }
+  });
+
+  function loadData(code) {
+    fetch(`https://api.worldbank.org/v2/country/${code}/indicator/SP.DYN.LE00.IN?format=json`)
+      .then(res => res.json())
+      .then(json => {
+        const data = json[1];
+        const years = [];
+        const values = [];
+        data.forEach(item => {
+          if (item.value !== null) {
+            years.push(item.date);
+            values.push(item.value);
+          }
+        });
+        years.reverse();
+        values.reverse();
+        chart.data.labels = years;
+        chart.data.datasets = [{
+          label: countries[code],
+          data: values,
+          borderColor: '#00FF00',
+          fill: false,
+          tension: 0.1
+        }];
+        chart.update();
+      });
+  }
+
+  select.addEventListener('change', () => loadData(select.value));
+  loadData(select.value || 'USA');
+});

--- a/scripts/version.js
+++ b/scripts/version.js
@@ -1,6 +1,6 @@
 // This file is automatically updated by the pre-commit hook
 window.APP_VERSION = {
-  commit: "88f0d91",
-  date: "2025-05-23T17:54:15Z",
-  timestamp: 1748022855000
+  commit: "0ffe395",
+  date: "2025-06-05T22:47:43Z",
+  timestamp: 1749163663000
 };

--- a/sitemap.html
+++ b/sitemap.html
@@ -51,6 +51,7 @@
         <a href="tamil.html">Tamil</a>
         <a href="age_calculator.html">Age Calculator</a>
         <a href="life_expectancy.html">Life Expectancy Calculator</a>
+        <a href="life_expectancy_viz.html">Life Expectancy Visualization</a>
         <a href="simple_systems.html">Simple Systems</a>
         <a href="braille.html">Braille Flashcards</a>
         <a href="morse_time.html">Morse Time</a>


### PR DESCRIPTION
## Summary
- add `life_expectancy_viz.html` for a dynamic Chart.js visualization
- add supporting script `life_expectancy_chart.js` that fetches World Bank data
- link new page from sitemap
- update site version

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68421dfe1d8c832cb621fa8a5e046ef8