### PR TITLE
Link calculator to new circle visualization

### DIFF
--- a/life_expectancy_viz.html
+++ b/life_expectancy_viz.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <title>Global Life Expectancy Visualization</title>
+  <title>Life Expectancy Time Left</title>
   <style>
   body {
     background-color: black;
@@ -23,24 +23,35 @@
   a:hover {
     color: #0066CC;
   }
-  #chartContainer {
+  #vizContainer {
     width: 100%;
-    max-width: 800px;
+    max-width: 400px;
     margin: 30px auto;
+    text-align: center;
+  }
+  canvas {
+    background-color: #111;
+    display: block;
+    margin: 0 auto;
   }
   </style>
 </head>
 <body>
-  <h1>Global Life Expectancy Over Time</h1>
-  <p>Select a country to see how life expectancy has changed through the years.</p>
-  <label for="countrySelect">Country:</label>
-  <select id="countrySelect"></select>
-  <div id="chartContainer">
-    <canvas id="lifeChart"></canvas>
+  <h1>Time Left Visualization</h1>
+  <p>Enter your birthdate and expected lifespan to visualize the time you have left.</p>
+  <label for="birthdate">Birthdate:</label>
+  <input type="date" id="birthdate">
+  <br><br>
+  <label for="expectancy">Expected lifespan (years):</label>
+  <input type="number" id="expectancy" min="1" step="1">
+  <br><br>
+  <button id="calculateLifeBtn">Visualize Time Left</button>
+  <div id="vizContainer">
+    <canvas id="lifeCircle" width="300" height="300"></canvas>
   </div>
   <p><a href="index.html">Back to Home</a></p>
-  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-  <script src="scripts/life_expectancy_chart.js" defer></script>
+  <script src="scripts/life_expectancy.js" defer></script>
+  <script src="scripts/life_expectancy_circle.js" defer></script>
   <footer>
     <hr>
     <div style="text-align: center;">

--- a/scripts/life_expectancy.js
+++ b/scripts/life_expectancy.js
@@ -24,6 +24,42 @@ function formatHumanReadable(number) {
   return formatted + suffixes[i];
 }
 
+function computeLifeStats(birthdateValue, expectancyValue) {
+  const birthDate = new Date(birthdateValue);
+  const currentDate = new Date();
+
+  if (!birthdateValue || isNaN(expectancyValue) || expectancyValue <= 0) {
+    return null;
+  }
+  if (isNaN(birthDate.getTime()) || birthDate > currentDate) {
+    return null;
+  }
+
+  const msPerYear = 365.25 * 24 * 60 * 60 * 1000;
+  const deathDate = new Date(birthDate.getTime() + expectancyValue * msPerYear);
+
+  let diffMilliseconds = deathDate.getTime() - currentDate.getTime();
+  if (diffMilliseconds < 0) diffMilliseconds = 0;
+
+  const totalSeconds = diffMilliseconds / 1000;
+  const totalMinutes = totalSeconds / 60;
+  const totalHours = totalMinutes / 60;
+  const totalDays = totalHours / 24;
+  const totalWeeks = totalDays / 7;
+  const totalMonths = totalDays / 30.4375;
+  const totalYears = totalMonths / 12;
+
+  return {
+    secondsRemaining: totalSeconds,
+    minutesRemaining: totalMinutes,
+    hoursRemaining: totalHours,
+    daysRemaining: totalDays,
+    weeksRemaining: totalWeeks,
+    monthsRemaining: totalMonths,
+    yearsRemaining: totalYears
+  };
+}
+
 function calculateLife() {
   const birthdateValue = document.getElementById('birthdate').value;
   const expectancyValue = parseFloat(document.getElementById('expectancy').value);
@@ -45,42 +81,17 @@ function calculateLife() {
   monthSpan.textContent = '';
   yearSpan.textContent = '';
 
-  if (!birthdateValue || isNaN(expectancyValue) || expectancyValue <= 0) {
+  const stats = computeLifeStats(birthdateValue, expectancyValue);
+  if (!stats) {
     alert('Please enter a valid birthdate and expected lifespan.');
     return;
   }
 
-  const birthDate = new Date(birthdateValue);
-  const currentDate = new Date();
-
-  if (isNaN(birthDate.getTime())) {
-    alert('Invalid birthdate format.');
-    return;
-  }
-  if (birthDate > currentDate) {
-    alert('Birthdate cannot be in the future.');
-    return;
-  }
-
-  const msPerYear = 365.25 * 24 * 60 * 60 * 1000;
-  const deathDate = new Date(birthDate.getTime() + expectancyValue * msPerYear);
-
-  let diffMilliseconds = deathDate.getTime() - currentDate.getTime();
-  if (diffMilliseconds < 0) diffMilliseconds = 0;
-
-  const totalSeconds = diffMilliseconds / 1000;
-  const totalMinutes = totalSeconds / 60;
-  const totalHours = totalMinutes / 60;
-  const totalDays = totalHours / 24;
-  const totalWeeks = totalDays / 7;
-  const totalMonths = totalDays / 30.4375;
-  const totalYears = totalMonths / 12;
-
-  secSpan.textContent = formatHumanReadable(totalSeconds);
-  minSpan.textContent = formatHumanReadable(totalMinutes);
-  hourSpan.textContent = formatHumanReadable(totalHours);
-  daySpan.textContent = formatHumanReadable(totalDays);
-  weekSpan.textContent = formatHumanReadable(totalWeeks);
-  monthSpan.textContent = formatHumanReadable(totalMonths);
-  yearSpan.textContent = formatHumanReadable(totalYears);
+  secSpan.textContent = formatHumanReadable(stats.secondsRemaining);
+  minSpan.textContent = formatHumanReadable(stats.minutesRemaining);
+  hourSpan.textContent = formatHumanReadable(stats.hoursRemaining);
+  daySpan.textContent = formatHumanReadable(stats.daysRemaining);
+  weekSpan.textContent = formatHumanReadable(stats.weeksRemaining);
+  monthSpan.textContent = formatHumanReadable(stats.monthsRemaining);
+  yearSpan.textContent = formatHumanReadable(stats.yearsRemaining);
 }

--- a/scripts/life_expectancy_circle.js
+++ b/scripts/life_expectancy_circle.js
@@ -1,0 +1,49 @@
+document.addEventListener('DOMContentLoaded', function() {
+  const btn = document.getElementById('calculateLifeBtn');
+  const canvas = document.getElementById('lifeCircle');
+  const ctx = canvas.getContext('2d');
+
+  function drawCircle(remaining, total) {
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    const centerX = canvas.width / 2;
+    const centerY = canvas.height / 2;
+    const radius = Math.min(centerX, centerY) - 10;
+    const startAngle = -0.5 * Math.PI;
+
+    // background circle
+    ctx.strokeStyle = '#444';
+    ctx.lineWidth = 20;
+    ctx.beginPath();
+    ctx.arc(centerX, centerY, radius, 0, 2 * Math.PI);
+    ctx.stroke();
+
+    const fraction = total > 0 ? remaining / total : 0;
+    ctx.strokeStyle = '#00FF00';
+    ctx.beginPath();
+    ctx.arc(centerX, centerY, radius, startAngle, startAngle + 2 * Math.PI * fraction);
+    ctx.stroke();
+
+    ctx.fillStyle = '#FFFFFF';
+    ctx.font = '20px Courier New, monospace';
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    const text = `${remaining.toFixed(1)} yrs left`;
+    ctx.fillText(text, centerX, centerY);
+  }
+
+  function handle() {
+    const birth = document.getElementById('birthdate').value;
+    const expectancy = parseFloat(document.getElementById('expectancy').value);
+    if (!birth || isNaN(expectancy) || expectancy <= 0) {
+      alert('Please enter a valid birthdate and expected lifespan.');
+      return;
+    }
+    const stats = computeLifeStats(birth, expectancy);
+    if (!stats) return;
+    drawCircle(stats.yearsRemaining, expectancy);
+  }
+
+  if (btn && canvas) {
+    btn.addEventListener('click', handle);
+  }
+});

--- a/scripts/version.js
+++ b/scripts/version.js
@@ -1,6 +1,6 @@
 // This file is automatically updated by the pre-commit hook
 window.APP_VERSION = {
-  commit: "0ffe395",
-  date: "2025-06-05T22:47:43Z",
-  timestamp: 1749163663000
+  commit: "f4c6d8c",
+  date: "2025-06-05T22:55:48Z",
+  timestamp: 1749164148000
 };


### PR DESCRIPTION
## Summary
- redesign life_expectancy_viz.html to visualize remaining time from the calculator
- factor out computation into `computeLifeStats` in life_expectancy.js
- add `life_expectancy_circle.js` to draw a circular gauge of years left
- update version metadata

## Testing
- `./update-version.sh`

------
https://chatgpt.com/codex/tasks/task_e_68421fe30084832c9b438fce6f3f4b6c