### PR TITLE
Revamp life expectancy visualization

### DIFF
--- a/life_expectancy.html
+++ b/life_expectancy.html
@@ -71,10 +71,15 @@ p {
   <label for="birthdate">Enter your birthdate:</label>
   <input type="date" id="birthdate">
   <br><br>
-  <label for="expectancy">Expected lifespan (years):</label>
-  <input type="number" id="expectancy" min="1" step="1">
+  <label for="gender">Gender:</label>
+  <select id="gender">
+    <option value="male">Male</option>
+    <option value="female">Female</option>
+  </select>
   <br><br>
   <button id="calculateLifeBtn">Calculate Time Left</button>
+
+  <p>Estimated life expectancy: <span id="estimatedExpectancy"></span> years</p>
 
   <p>Seconds remaining: <span id="lifeSeconds"></span></p>
   <p>Minutes remaining: <span id="lifeMinutes"></span></p>

--- a/life_expectancy_viz.html
+++ b/life_expectancy_viz.html
@@ -38,17 +38,22 @@
 </head>
 <body>
   <h1>Time Left Visualization</h1>
-  <p>Enter your birthdate and expected lifespan to visualize the time you have left.</p>
+  <p>Enter your birthdate and gender to visualize the time you have left.</p>
   <label for="birthdate">Birthdate:</label>
   <input type="date" id="birthdate">
   <br><br>
-  <label for="expectancy">Expected lifespan (years):</label>
-  <input type="number" id="expectancy" min="1" step="1">
+  <label for="gender">Gender:</label>
+  <select id="gender">
+    <option value="male">Male</option>
+    <option value="female">Female</option>
+  </select>
   <br><br>
   <button id="calculateLifeBtn">Visualize Time Left</button>
   <div id="vizContainer">
     <canvas id="lifeCircle" width="300" height="300"></canvas>
+    <canvas id="lifeBar" width="300" height="40" style="margin-top:20px;"></canvas>
   </div>
+  <p>Estimated life expectancy: <span id="estimatedExpectancy"></span> years</p>
   <p><a href="index.html">Back to Home</a></p>
   <script src="scripts/life_expectancy.js" defer></script>
   <script src="scripts/life_expectancy_circle.js" defer></script>

--- a/scripts/life_expectancy.js
+++ b/scripts/life_expectancy.js
@@ -1,4 +1,4 @@
-// Calculate remaining life based on birthdate and expected lifespan
+// Calculate remaining life based on birthdate and estimated lifespan
 
 document.addEventListener('DOMContentLoaded', function() {
   const btn = document.getElementById('calculateLifeBtn');
@@ -22,6 +22,32 @@ function formatHumanReadable(number) {
   const scaled = number / Math.pow(1000, i);
   const formatted = (scaled % 1 === 0) ? scaled.toFixed(0) : scaled.toFixed(1);
   return formatted + suffixes[i];
+}
+
+// Rough life expectancy estimates by decade in the U.S.
+const lifeExpectancyData = {
+  male: {
+    1900: 46.3, 1910: 48.4, 1920: 53.6, 1930: 58.1,
+    1940: 60.8, 1950: 65.6, 1960: 66.6, 1970: 67.1,
+    1980: 70.0, 1990: 72.7, 2000: 74.3, 2010: 76.2,
+    2020: 77.3
+  },
+  female: {
+    1900: 48.3, 1910: 51.5, 1920: 54.6, 1930: 61.1,
+    1940: 65.2, 1950: 71.1, 1960: 73.1, 1970: 74.7,
+    1980: 77.5, 1990: 79.4, 2000: 79.9, 2010: 81.0,
+    2020: 82.1
+  }
+};
+
+function estimateLifeExpectancy(year, gender) {
+  const table = lifeExpectancyData[gender.toLowerCase()] || lifeExpectancyData.male;
+  const years = Object.keys(table).map(Number).sort((a, b) => a - b);
+  let closest = years[0];
+  for (const y of years) {
+    if (year >= y) closest = y; else break;
+  }
+  return table[closest];
 }
 
 function computeLifeStats(birthdateValue, expectancyValue) {
@@ -62,7 +88,14 @@ function computeLifeStats(birthdateValue, expectancyValue) {
 
 function calculateLife() {
   const birthdateValue = document.getElementById('birthdate').value;
-  const expectancyValue = parseFloat(document.getElementById('expectancy').value);
+  const genderValue = (document.getElementById('gender') || { value: 'male' }).value;
+  const birthYear = new Date(birthdateValue).getFullYear();
+  const expectancyValue = estimateLifeExpectancy(birthYear, genderValue);
+
+  const expectancyDisplay = document.getElementById('estimatedExpectancy');
+  if (expectancyDisplay && !isNaN(expectancyValue)) {
+    expectancyDisplay.textContent = expectancyValue.toFixed(1);
+  }
 
   // Output spans
   const secSpan = document.getElementById('lifeSeconds');
@@ -83,7 +116,7 @@ function calculateLife() {
 
   const stats = computeLifeStats(birthdateValue, expectancyValue);
   if (!stats) {
-    alert('Please enter a valid birthdate and expected lifespan.');
+    alert('Please enter a valid birthdate and gender.');
     return;
   }
 

--- a/scripts/life_expectancy_circle.js
+++ b/scripts/life_expectancy_circle.js
@@ -1,7 +1,9 @@
 document.addEventListener('DOMContentLoaded', function() {
   const btn = document.getElementById('calculateLifeBtn');
   const canvas = document.getElementById('lifeCircle');
+  const bar = document.getElementById('lifeBar');
   const ctx = canvas.getContext('2d');
+  const barCtx = bar.getContext('2d');
 
   function drawCircle(remaining, total) {
     ctx.clearRect(0, 0, canvas.width, canvas.height);
@@ -31,16 +33,28 @@ document.addEventListener('DOMContentLoaded', function() {
     ctx.fillText(text, centerX, centerY);
   }
 
+  function drawBar(remaining, total) {
+    barCtx.clearRect(0, 0, bar.width, bar.height);
+    const fraction = total > 0 ? remaining / total : 0;
+    barCtx.fillStyle = '#444';
+    barCtx.fillRect(0, 0, bar.width, bar.height);
+    barCtx.fillStyle = '#00FF00';
+    barCtx.fillRect(0, 0, bar.width * fraction, bar.height);
+  }
+
   function handle() {
     const birth = document.getElementById('birthdate').value;
-    const expectancy = parseFloat(document.getElementById('expectancy').value);
-    if (!birth || isNaN(expectancy) || expectancy <= 0) {
-      alert('Please enter a valid birthdate and expected lifespan.');
+    const gender = (document.getElementById('gender') || { value: 'male' }).value;
+    const birthYear = new Date(birth).getFullYear();
+    const expectancy = estimateLifeExpectancy(birthYear, gender);
+    if (!birth || isNaN(expectancy)) {
+      alert('Please enter a valid birthdate and gender.');
       return;
     }
     const stats = computeLifeStats(birth, expectancy);
     if (!stats) return;
     drawCircle(stats.yearsRemaining, expectancy);
+    drawBar(stats.yearsRemaining, expectancy);
   }
 
   if (btn && canvas) {


### PR DESCRIPTION
## Summary
- estimate life expectancy automatically from gender and birth year
- add horizontal bar visualization of remaining years
- replace lifespan field with gender dropdown
- display estimated life expectancy

## Testing
- `node --check scripts/life_expectancy.js`
- `node --check scripts/life_expectancy_circle.js`


------
https://chatgpt.com/codex/tasks/task_e_684221a42dd8832ca82238d8f6d83855