### PR TITLE
Remove grey from life expectancy visualization

### DIFF
--- a/life_expectancy_viz.html
+++ b/life_expectancy_viz.html
@@ -42,7 +42,7 @@
     color: black;
   }
   canvas {
-    background-color: #111;
+    background-color: black;
     display: block;
     margin: 0 auto;
   }

--- a/scripts/life_expectancy_circle.js
+++ b/scripts/life_expectancy_circle.js
@@ -13,7 +13,7 @@ document.addEventListener('DOMContentLoaded', function() {
     const startAngle = -0.5 * Math.PI;
 
     // background circle
-    ctx.strokeStyle = '#444';
+    ctx.strokeStyle = 'black';
     ctx.lineWidth = 20;
     ctx.beginPath();
     ctx.arc(centerX, centerY, radius, 0, 2 * Math.PI);
@@ -36,7 +36,7 @@ document.addEventListener('DOMContentLoaded', function() {
   function drawBar(remaining, total) {
     barCtx.clearRect(0, 0, bar.width, bar.height);
     const fraction = total > 0 ? remaining / total : 0;
-    barCtx.fillStyle = '#444';
+    barCtx.fillStyle = 'black';
     barCtx.fillRect(0, 0, bar.width, bar.height);
     barCtx.fillStyle = '#00FF00';
     barCtx.fillRect(0, 0, bar.width * fraction, bar.height);

--- a/scripts/version.js
+++ b/scripts/version.js
@@ -1,6 +1,6 @@
 // This file is automatically updated by the pre-commit hook
 window.APP_VERSION = {
-  commit: "e3b375b",
-  date: "2025-06-05T23:25:23Z",
-  timestamp: 1749165923000
+  commit: "a20c23a",
+  date: "2025-06-06T02:47:30Z",
+  timestamp: 1749178050000
 };


### PR DESCRIPTION
## Summary
- darken the life expectancy visualization canvas background
- remove grey color from visualization circle and bar

## Testing
- `python3 -m py_compile scholar_scraper.py`

------
https://chatgpt.com/codex/tasks/task_e_68425670e198832c8e84e9bb1b80daff