### PR TITLE
Add streamlined links with new category pages

### DIFF
--- a/about_me.html
+++ b/about_me.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>About Me - Karthik Balasubramanian</title>
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body class="links-dark-theme">
+
+<div class="content-cell">
+    <div class="section">
+        <h1>About Me</h1>
+        <div class="link-cards-container">
+            <div class="link-card">
+                <a href="about.html">Biography</a>
+            </div>
+            <div class="link-card">
+                <a href="education.html">Education</a>
+            </div>
+            <div class="link-card">
+                <a href="contact.html">Contact Info</a>
+            </div>
+            <div class="link-card">
+                <a href="socials.html">Socials</a>
+            </div>
+        </div>
+    </div>
+</div>
+
+<script src="scripts/keyboard_nav.js"></script>
+</body>
+</html>

--- a/helpful_tools.html
+++ b/helpful_tools.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Helpful Tools - Karthik Balasubramanian</title>
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body class="links-dark-theme">
+
+<div class="content-cell">
+    <div class="section">
+        <h1>Helpful Tools</h1>
+        <div class="link-cards-container">
+            <div class="link-card">
+                <a href="morse.html">Morse Tools</a>
+            </div>
+            <div class="link-card">
+                <a href="braille.html">Braille Flashcards</a>
+            </div>
+            <div class="link-card">
+                <a href="life_expectancy_viz.html">Life Expectancy Viz</a>
+            </div>
+            <div class="link-card">
+                <a href="random_generator.html">Random Generator</a>
+            </div>
+            <div class="link-card">
+                <a href="simple_systems.html">Simple Systems</a>
+            </div>
+            <div class="link-card">
+                <a href="polar_clock.html">Polar Clock</a>
+            </div>
+        </div>
+    </div>
+</div>
+
+<script src="scripts/keyboard_nav.js"></script>
+</body>
+</html>

--- a/links.html
+++ b/links.html
@@ -11,10 +11,7 @@
         <h2>Links</h2>
         <div class="link-cards-container">
             <div class="link-card">
-                <a href="about.html">About Me</a>
-            </div>
-            <div class="link-card">
-                <a href="education.html">Education</a>
+                <a href="about_me.html">About Me</a>
             </div>
             <div class="link-card">
                 <a href="expertise.html">Research Expertise</a>
@@ -26,25 +23,7 @@
                 <a href="publications.html">Publications</a>
             </div>
             <div class="link-card">
-                <a href="contact.html">Contact Information</a>
-            </div>
-            <div class="link-card">
-                <a href="socials.html">Socials</a>
-            </div>
-            <div class="link-card">
-                <a href="braille.html">Braille Flashcards</a>
-            </div>
-            <div class="link-card">
-                <a href="morse.html">Morse Tools</a>
-            </div>
-            <div class="link-card">
-                <a href="simple_systems.html">Simple Systems</a>
-            </div>
-            <div class="link-card">
-                <a href="polar_clock.html">Polar Clock</a>
-            </div>
-            <div class="link-card">
-                <a href="random_generator.html">Random Generator</a>
+                <a href="helpful_tools.html">Helpful Tools</a>
             </div>
             <div class="link-card">
                 <a href="heroes.html">Heroes</a>
@@ -54,7 +33,7 @@
             </div>
         </div>
         <hr>
-        <p><em>Last updated: May 5, 2025</em></p>
+        <p><em>Last updated: June 8, 2025</em></p>
     </div> <!-- section -->
 </div> <!-- content-cell -->
 


### PR DESCRIPTION
## Summary
- add `about_me.html` and `helpful_tools.html` interstitial pages
- simplify `links.html` to highlight categories
- keep keyboard navigation hotkeys on all pages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684301092814832ca106ef6a0df1aba3