### PR TITLE
Add inspiration section and reorganize links

### DIFF
--- a/about_me.html
+++ b/about_me.html
@@ -22,6 +22,15 @@
             <div class="link-card">
                 <a href="socials.html">Socials</a>
             </div>
+            <div class="link-card">
+                <a href="teaching.html">Teaching</a>
+            </div>
+            <div class="link-card">
+                <a href="expertise.html">Research</a>
+            </div>
+            <div class="link-card">
+                <a href="publications.html">Publications</a>
+            </div>
         </div>
     </div>
 </div>

--- a/helpful_tools.html
+++ b/helpful_tools.html
@@ -17,10 +17,15 @@
                 <a href="braille.html">Braille Flashcards</a>
             </div>
             <div class="link-card">
-                <a href="life_expectancy_viz.html">Life Expectancy Viz</a>
-            </div>
-            <div class="link-card">
                 <a href="random_generator.html">Random Generator</a>
+            </div>
+        </div>
+    </div>
+    <div class="section">
+        <h1>Cool Visualizations</h1>
+        <div class="link-cards-container">
+            <div class="link-card">
+                <a href="life_expectancy_viz.html">Life Expectancy Viz</a>
             </div>
             <div class="link-card">
                 <a href="simple_systems.html">Simple Systems</a>

--- a/index.html
+++ b/index.html
@@ -55,6 +55,11 @@ ul {
   border: 1px solid white; /* Optional: adds a border around the image */
   max-height: 200px;    /* Optional: constrain maximum height */
 }
+
+/* Hide keyboard shortcut hints but keep functionality */
+.hotkey {
+  display: none;
+}
 </style>
 </head>
 <body>

--- a/inspirational_clips.html
+++ b/inspirational_clips.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Inspirational Clips - Karthik Balasubramanian</title>
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body class="links-dark-theme">
+<div class="content-cell">
+    <div class="section">
+        <h1>Inspirational Clips</h1>
+        <div style="display:flex;flex-direction:column;gap:20px;align-items:center;">
+            <iframe width="560" height="315" src="https://www.youtube.com/embed/ZXsQAXx_ao0" title="Just Do It" frameborder="0" allowfullscreen></iframe>
+            <iframe width="560" height="315" src="https://www.youtube.com/embed/DVx8L7aCdmM" title="Rocky Speech" frameborder="0" allowfullscreen></iframe>
+        </div>
+    </div>
+</div>
+<script src="scripts/keyboard_nav.js"></script>
+</body>
+</html>

--- a/inspirational_quotes.html
+++ b/inspirational_quotes.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Inspirational Quotes - Karthik Balasubramanian</title>
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body class="links-dark-theme">
+<div class="content-cell">
+    <div class="section">
+        <h1>Inspirational Quotes</h1>
+        <ul class="bullet-list">
+            <li>"Be yourself; everyone else is already taken." – Oscar Wilde</li>
+            <li>"The only way to do great work is to love what you do." – Steve Jobs</li>
+            <li>"If you want to go fast, go alone. If you want to go far, go together." – African Proverb</li>
+        </ul>
+    </div>
+</div>
+<script src="scripts/keyboard_nav.js"></script>
+</body>
+</html>

--- a/links.html
+++ b/links.html
@@ -26,15 +26,29 @@
                 <a href="helpful_tools.html">Helpful Tools</a>
             </div>
             <div class="link-card">
-                <a href="heroes.html">Heroes</a>
-            </div>
-            <div class="link-card">
                 <a href="sitemap.html">Sitemap</a>
             </div>
         </div>
         <hr>
         <p><em>Last updated: June 8, 2025</em></p>
     </div> <!-- section -->
+</div> <!-- content-cell -->
+
+<div class="content-cell">
+    <div class="section">
+        <h2>Inspiration</h2>
+        <div class="link-cards-container">
+            <div class="link-card">
+                <a href="heroes.html">Heroes</a>
+            </div>
+            <div class="link-card">
+                <a href="inspirational_quotes.html">Inspirational Quotes</a>
+            </div>
+            <div class="link-card">
+                <a href="inspirational_clips.html">Inspirational Clips</a>
+            </div>
+        </div>
+    </div>
 </div> <!-- content-cell -->
 
 <div class="language">

--- a/sitemap.html
+++ b/sitemap.html
@@ -49,6 +49,8 @@
         <a href="links.html">Links</a>
         <a href="sitemap.html">Sitemap</a>
         <a href="heroes.html">Heroes</a>
+        <a href="inspirational_quotes.html">Inspirational Quotes</a>
+        <a href="inspirational_clips.html">Inspirational Clips</a>
         <a href="tamil.html">Tamil</a>
         <a href="life_expectancy_viz.html">Life Expectancy Visualization</a>
         <a href="simple_systems.html">Simple Systems</a>


### PR DESCRIPTION
## Summary
- hide hotkey hints on the home page
- extend About Me with teaching, research and publications
- split Helpful Tools into Helpful Tools and Cool Visualizations
- create Inspiration section with links to Heroes, quotes and clips
- add Inspirational Quotes and Inspirational Clips pages
- update sitemap with new pages

## Testing
- `python -m py_compile scholar_scraper.py`
- `python scripts/generate_image_list.py` *(fails: Pillow not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68430308c410832caaf5c0a53b9d410f