### PR TITLE
Fix helpful tools links

### DIFF
--- a/helpful_tools.html
+++ b/helpful_tools.html
@@ -22,18 +22,9 @@
         </div>
     </div>
     <div class="section">
-        <h1>Cool Visualizations</h1>
-        <div class="link-cards-container">
-            <div class="link-card">
-                <a href="life_expectancy_viz.html">Life Expectancy Viz</a>
-            </div>
-            <div class="link-card">
-                <a href="simple_systems.html">Simple Systems</a>
-            </div>
-            <div class="link-card">
-                <a href="polar_clock.html">Polar Clock</a>
-            </div>
-        </div>
+        <p>Looking for visualizations? Visit the
+            <a href="cool_visualizations.html">Cool Visualizations</a>
+            page for interactive demos.</p>
     </div>
 </div>
 


### PR DESCRIPTION
## Summary
- remove the duplicate Cool Visualizations section from the Helpful Tools page
- direct users to the dedicated Cool Visualizations page instead

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68437b167344832cb5f5146c65004b8c