### PR TITLE
Add GDP Time-Series Visualizer

### DIFF
--- a/cool_visualizations.html
+++ b/cool_visualizations.html
@@ -22,6 +22,12 @@
             <div class="link-card">
                 <a href="polar_clock.html">Polar Clock</a>
             </div>
+            <div class="link-card">
+                <a href="gdp_visualizer.html">GDP Time-Series Visualizer</a>
+            </div>
+            <div class="link-card">
+                <a href="gdp_timeseries_prd.html">GDP Time-Series Visualizer PRD</a>
+            </div>
         </div>
     </div>
 </div>

--- a/gdp_timeseries_prd.html
+++ b/gdp_timeseries_prd.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>GDP Time-Series Visualizer PRD</title>
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body class="links-dark-theme">
+<div class="content-cell">
+    <h1>GDP Time-Series Visualizer</h1>
+
+    <h2>1. Introduction</h2>
+    <p>This document outlines a minimalist web tool for visualizing a country's historical Gross Domestic Product (GDP). The goal is to present complex economic data in a clean, highly legible format using a strictly black and white palette.</p>
+
+    <h2>2. Vision and Opportunity</h2>
+    <p>The visualizer transforms dense economic data into a simple narrative. By focusing on typography and negative space, it aims to make macroeconomic trends engaging for students, journalists, and curious readers alike.</p>
+
+    <h2>3. Target Audience</h2>
+    <ul class="bullet-list">
+        <li><strong>Primary:</strong> Students, educators, and journalists.</li>
+        <li><strong>Secondary:</strong> Business professionals, financial analysts, and researchers.</li>
+        <li><strong>Tertiary:</strong> Anyone curious about global economics.</li>
+    </ul>
+
+    <h2>4. User Flow</h2>
+    <ol class="bullet-list">
+        <li>Landing page prompts the user with <em>"TYPE A COUNTRY"</em>.</li>
+        <li>After submission, the screen transitions to the GDP visualization.</li>
+    </ol>
+
+    <h2>5. Aesthetic &amp; Design Requirements</h2>
+    <p>The interface follows a strict black (<code>#000000</code>) background with white (<code>#FFFFFF</code>) typography and chart elements. The country name appears in a bold sans-serif display font such as Inter Bold or Helvetica Now Display. Axes and labels use a highly readable sans-serif like Inter or SF Pro Text. No gradients, shadows, or other ornamentation are used.</p>
+
+    <h2>6. Functional Requirements</h2>
+    <ul class="bullet-list">
+        <li>Smart country input that recognizes common aliases (e.g., "USA" or "United States").</li>
+        <li>Fetch historical GDP in current US dollars from a local database.</li>
+        <li>Render a vertical bar chart with an overlaid smoothed line graph, clearly labeling axes.</li>
+        <li>Minimal interactive controls: an information/source toggle and a shareable URL button.</li>
+    </ul>
+
+    <h2>7. Data Requirements</h2>
+    <p>Data originates from the World Bank's GDP (current US$) dataset. The data is cleaned and stored locally for quick queries, covering available years from 1960 onward.</p>
+
+    <h2>8. Minimum Viable Product</h2>
+    <ul class="bullet-list">
+        <li>Input supporting at least 100 major countries and their aliases.</li>
+        <li>Database populated with World Bank GDP data.</li>
+        <li>Complete visualization in the high-legibility aesthetic.</li>
+        <li>Working info/source panel and shareable links.</li>
+    </ul>
+
+    <h2>9. Future Enhancements</h2>
+    <ul class="bullet-list">
+        <li>Additional economic indicators such as GDP per capita and GDP growth.</li>
+        <li>Ability to compare multiple countries on one graph.</li>
+        <li>Logarithmic scale toggle.</li>
+        <li>Currency conversion options and data export functions.</li>
+    </ul>
+
+    <p><a href="cool_visualizations.html">Back to Cool Visualizations</a></p>
+</div>
+
+<script src="scripts/keyboard_nav.js"></script>
+</body>
+</html>

--- a/gdp_visualizer.html
+++ b/gdp_visualizer.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>GDP Time-Series Visualizer</title>
+  <style>
+    body {
+      background-color: black;
+      color: white;
+      font-family: Arial, sans-serif;
+      margin: 0;
+      padding: 20px;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      text-align: center;
+    }
+    h1 {
+      font-size: 3em;
+      margin-bottom: 20px;
+      font-weight: bold;
+    }
+    #input-container {
+      margin-bottom: 20px;
+    }
+    #countryInput {
+      background: black;
+      border: 1px solid white;
+      color: white;
+      padding: 10px;
+      font-size: 1.2em;
+      width: 250px;
+    }
+    button {
+      background: black;
+      color: white;
+      border: 1px solid white;
+      padding: 10px 16px;
+      font-size: 1em;
+      cursor: pointer;
+      margin-left: 5px;
+    }
+    canvas {
+      max-width: 90vw;
+      max-height: 60vh;
+    }
+    #infoPanel {
+      display: none;
+      font-size: 0.9em;
+      color: #cccccc;
+      margin-top: 10px;
+    }
+  </style>
+</head>
+<body>
+  <div id="input-container">
+    <input id="countryInput" type="text" placeholder="United States">
+    <button id="loadButton">Load</button>
+    <button id="infoToggle">Info</button>
+  </div>
+  <h1 id="countryName"></h1>
+  <canvas id="gdpChart" width="800" height="400"></canvas>
+  <div id="infoPanel">Data from the World Bank (GDP current US$)</div>
+  <p style="margin-top:20px;"><a href="cool_visualizations.html" style="color:#87CEFA;">← Back</a></p>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.3.0/dist/chart.umd.min.js"></script>
+  <script src="scripts/gdp_visualizer.js"></script>
+  <script src="scripts/keyboard_nav.js"></script>
+</body>
+</html>

--- a/scripts/gdp_visualizer.js
+++ b/scripts/gdp_visualizer.js
@@ -1,0 +1,124 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const aliasMap = {
+    'usa': 'USA',
+    'united states': 'USA',
+    'united states of america': 'USA',
+    'us': 'USA',
+    'india': 'IND',
+    'ind': 'IND',
+    'china': 'CHN',
+    'united kingdom': 'GBR',
+    'uk': 'GBR',
+    'japan': 'JPN',
+    'canada': 'CAN',
+    'germany': 'DEU',
+    'france': 'FRA'
+  };
+
+  const input = document.getElementById('countryInput');
+  const loadBtn = document.getElementById('loadButton');
+  const infoToggle = document.getElementById('infoToggle');
+  const infoPanel = document.getElementById('infoPanel');
+  const nameEl = document.getElementById('countryName');
+  const ctx = document.getElementById('gdpChart').getContext('2d');
+  let chart;
+
+  function canonical(name) {
+    const key = name.toLowerCase().trim();
+    return aliasMap[key] || null;
+  }
+
+  function formatTick(value) {
+    if (value >= 1e12) return '$' + (value/1e12).toFixed(0) + 'T';
+    if (value >= 1e9) return '$' + (value/1e9).toFixed(0) + 'B';
+    if (value >= 1e6) return '$' + (value/1e6).toFixed(0) + 'M';
+    if (value >= 1e3) return '$' + (value/1e3).toFixed(0) + 'K';
+    return '$' + value;
+  }
+
+  async function loadData(query) {
+    const code = canonical(query);
+    if (!code) {
+      alert('Country not recognized');
+      return;
+    }
+    const res = await fetch(`https://api.worldbank.org/v2/country/${code}/indicator/NY.GDP.MKTP.CD?format=json`);
+    const json = await res.json();
+    const data = json[1];
+    if (!data) {
+      alert('No data found');
+      return;
+    }
+    const years = [];
+    const values = [];
+    data.forEach(d => {
+      if (d.value !== null) {
+        years.push(d.date);
+        values.push(d.value);
+      }
+    });
+    years.reverse();
+    values.reverse();
+    nameEl.textContent = data[0].country.value;
+
+    const barData = {
+      type: 'bar',
+      label: 'GDP',
+      data: values,
+      backgroundColor: 'rgba(255,255,255,0.2)',
+      borderColor: 'rgba(255,255,255,0.5)',
+      borderWidth: 1,
+    };
+    const lineData = {
+      type: 'line',
+      label: 'GDP',
+      data: values,
+      borderColor: '#ffffff',
+      backgroundColor: 'transparent',
+      borderWidth: 2,
+      tension: 0.2,
+    };
+
+    if (chart) {
+      chart.data.labels = years;
+      chart.data.datasets = [barData, lineData];
+      chart.update();
+    } else {
+      chart = new Chart(ctx, {
+        data: {
+          labels: years,
+          datasets: [barData, lineData]
+        },
+        options: {
+          responsive: true,
+          scales: {
+            x: {
+              ticks: { color: '#ffffff' },
+              grid: { color: 'rgba(255,255,255,0.2)' }
+            },
+            y: {
+              ticks: {
+                color: '#ffffff',
+                callback: formatTick
+              },
+              grid: { color: 'rgba(255,255,255,0.2)' }
+            }
+          },
+          plugins: {
+            legend: { display: false }
+          }
+        }
+      });
+    }
+  }
+
+  loadBtn.addEventListener('click', () => loadData(input.value));
+  input.addEventListener('keyup', (e) => {
+    if (e.key === 'Enter') loadData(input.value);
+  });
+  infoToggle.addEventListener('click', () => {
+    infoPanel.style.display = infoPanel.style.display === 'block' ? 'none' : 'block';
+  });
+
+  loadData('United States');
+});

--- a/sitemap.html
+++ b/sitemap.html
@@ -64,6 +64,8 @@
         <a href="send_money.html">Send Money</a>
         <a href="polar_clock.html">Polar Clock</a>
         <a href="random_generator.html">Random Generator</a>
+        <a href="gdp_visualizer.html">GDP Time-Series Visualizer</a>
+        <a href="gdp_timeseries_prd.html">GDP Time-Series Visualizer PRD</a>
     </div>
 <script src="scripts/keyboard_nav.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- add an interactive GDP visualization page using Chart.js
- implement script to fetch World Bank GDP data
- link the visualization from Cool Visualizations
- list the new page in the sitemap

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68437ecfa3e0832cbf1fd4ca69aa6743