### PR TITLE
Add interactive GDP clip mask

### DIFF
--- a/cool_visualizations.html
+++ b/cool_visualizations.html
@@ -26,6 +26,9 @@
                 <a href="gdp_visualizer.html">GDP Time-Series Visualizer</a>
             </div>
             <div class="link-card">
+                <a href="gdp_clipmask.html">GDP Clip Mask Demo</a>
+            </div>
+            <div class="link-card">
                 <a href="gdp_timeseries_prd.html">GDP Time-Series Visualizer PRD</a>
             </div>
         </div>

--- a/gdp_clipmask.html
+++ b/gdp_clipmask.html
@@ -1,47 +1,301 @@
 <!DOCTYPE html>
-<!-- Static example for United States. Replace the data array and text in gdp_mask.js with user input for a dynamic version. -->
 <html lang="en">
 <head>
-<meta charset="UTF-8">
-<title>GDP Clip Mask Demo</title>
-<style>
-  body {
-    margin: 0;
-    background-color: #007BFF;
-    color: white;
-    font-family: Arial, sans-serif;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    height: 100vh;
-  }
-  .country-name {
-    font-weight: bold;
-    font-size: 120px;
-    text-anchor: middle;
-    dominant-baseline: middle;
-    fill: white;
-  }
-  .attribution {
-    font-size: 12px;
-    fill: white;
-  }
-  .axis path,
-  .axis line {
-    stroke: white;
-  }
-  .axis text {
-    fill: white;
-    font-size: 12px;
-  }
-  .y.axis .tick line {
-    stroke-dasharray: 4;
-  }
-</style>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>GDP Visualization</title>
+    <style>
+        /* --- Basic Setup & Typography --- */
+        html, body {
+            height: 100%;
+            margin: 0;
+            padding: 0;
+            overflow: hidden;
+            background-color: #007BFF; /* Vibrant Blue Background */
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+            color: white;
+        }
+
+        /* --- Layout Containers --- */
+        #container {
+            position: relative;
+            width: 100%;
+            height: 100%;
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            align-items: center;
+        }
+
+        #placeholder {
+            font-size: 5vw;
+            font-weight: bold;
+            text-transform: uppercase;
+            letter-spacing: 0.1em;
+            opacity: 1;
+            transition: opacity 0.3s ease-in-out;
+        }
+
+        #chart-container {
+            width: 90%;
+            height: 70%;
+            opacity: 0;
+            transition: opacity 0.3s ease-in-out;
+        }
+        
+        #chart-container.visible, #placeholder.hidden {
+            opacity: 1;
+        }
+        
+        #placeholder.hidden, #chart-container.hidden {
+            opacity: 0;
+            pointer-events: none;
+        }
+        
+        #title {
+            position: absolute;
+            top: 5%;
+            right: 5%;
+            font-size: 1.2em;
+            font-weight: 500;
+        }
+        
+        #footer {
+            position: absolute;
+            bottom: 5%;
+            font-size: 0.9em;
+            opacity: 0.7;
+        }
+
+        /* --- SVG & D3 Chart Styling --- */
+        svg {
+            overflow: visible; /* Allows labels to be outside the main area */
+        }
+        
+        /* The Giant Masked Text */
+        .country-text {
+            font-size: 20vh; /* Responsive font size */
+            font-weight: 900; /* Extra bold */
+            text-anchor: middle;
+            fill: white;
+            text-transform: uppercase;
+            letter-spacing: -0.02em;
+        }
+
+        /* Data Lines (Outline + Main) */
+        .line-outline {
+            fill: none;
+            stroke: white;
+            stroke-width: 5px;
+            stroke-linejoin: round;
+            stroke-linecap: round;
+        }
+        .line {
+            fill: none;
+            stroke: #222; /* Dark grey */
+            stroke-width: 2px;
+            stroke-linejoin: round;
+            stroke-linecap: round;
+        }
+
+        /* Axes & Gridlines */
+        .axis path,
+        .axis line {
+            stroke: white;
+        }
+
+        .axis text {
+            fill: white;
+            font-size: 14px;
+        }
+        
+        .grid-line {
+            stroke: white;
+            stroke-opacity: 0.2;
+            stroke-dasharray: 4, 4; /* Dashed lines */
+        }
+        
+        .axis .domain {
+            stroke-width: 1.5px;
+        }
+    </style>
 </head>
 <body>
-<svg id="chart" width="900" height="500"></svg>
-<script src="https://d3js.org/d3.v7.min.js"></script>
-<script src="scripts/gdp_mask.js"></script>
+
+    <div id="container">
+        <div id="title">Yearly Gross Domestic Product (USD)</div>
+        
+        <div id="placeholder">Type a Country</div>
+        
+        <div id="chart-container" class="hidden">
+            <!-- D3.js will render the SVG chart here -->
+        </div>
+        
+        <div id="footer">Data from World Bank | Experiment</div>
+    </div>
+
+    <!-- D3.js Library -->
+    <script src="https://d3js.org/d3.v7.min.js"></script>
+
+    <script>
+        // --- 1. SAMPLE DATA ---
+        // In a real application, you would fetch this from an API.
+        const gdpData = {
+            "UNITED STATES": [
+                { year: 1975, gdp: 1.69 }, { year: 1980, gdp: 2.86 }, { year: 1985, gdp: 4.34 },
+                { year: 1990, gdp: 5.98 }, { year: 1995, gdp: 7.66 }, { year: 2000, gdp: 10.28 },
+                { year: 2005, gdp: 13.09 }, { year: 2008, gdp: 14.71 }, { year: 2009, gdp: 14.41 },
+                { year: 2010, gdp: 14.96 }, { year: 2015, gdp: 18.22 }, { year: 2020, gdp: 21.06 },
+                { year: 2021, gdp: 23.32 }, { year: 2022, gdp: 25.46 }, { year: 2023, gdp: 27.36 }
+            ]
+            // Add more countries here...
+        };
+
+        // --- 2. D3 SETUP ---
+        const container = d3.select("#chart-container");
+        const placeholder = d3.select("#placeholder");
+        
+        const margin = { top: 20, right: 30, bottom: 40, left: 60 };
+        let width, height; // Will be set dynamically
+
+        let svg;
+        let currentCountryName = '';
+
+        function setupChart() {
+            const containerRect = container.node().getBoundingClientRect();
+            width = containerRect.width - margin.left - margin.right;
+            height = containerRect.height - margin.top - margin.bottom;
+
+            // Clear previous SVG and create a new one
+            container.html(''); 
+            svg = container.append("svg")
+                .attr("width", width + margin.left + margin.right)
+                .attr("height", height + margin.top + margin.bottom)
+              .append("g")
+                .attr("transform", `translate(${margin.left},${margin.top})`);
+        }
+
+        // --- 3. DRAWING FUNCTION ---
+        function drawChart(countryName) {
+            if (!svg) setupChart();
+
+            // Clear previous drawing
+            svg.selectAll("*").remove();
+            
+            const data = gdpData["UNITED STATES"] || []; // Use US data as a fallback/demo
+
+            // --- Scales ---
+            const xScale = d3.scaleTime()
+                .domain(d3.extent(data, d => d.year))
+                .range([0, width]);
+
+            const yScale = d3.scaleLinear()
+                .domain([0, d3.max(data, d => d.gdp) * 1.1]) // Add 10% padding to top
+                .range([height, 0]);
+
+            // --- Axes ---
+            const xAxis = d3.axisBottom(xScale).tickFormat(d3.format("d"));
+            const yAxis = d3.axisLeft(yScale).ticks(5).tickFormat(d => `$${d}T`);
+
+            svg.append("g")
+                .attr("class", "axis")
+                .attr("transform", `translate(0,${height})`)
+                .call(xAxis);
+
+            svg.append("g")
+                .attr("class", "axis")
+                .call(yAxis);
+
+            // --- Grid Lines ---
+            svg.append("g")
+                .attr("class", "grid")
+                .call(d3.axisLeft(yScale)
+                    .ticks(5)
+                    .tickSize(-width)
+                    .tickFormat("")
+                )
+                .selectAll("line")
+                .attr("class", "grid-line");
+
+            // --- THE CORE MASKING EFFECT ---
+            // 1. Define an area generator for the clip path
+            const area = d3.area()
+                .x(d => xScale(d.year))
+                .y0(height)
+                .y1(d => yScale(d.gdp));
+
+            // 2. Create a <defs> and a <clipPath>
+            const defs = svg.append("defs");
+            const clipPath = defs.append("clipPath")
+                .attr("id", "text-clipper");
+
+            // 3. Add the area path to the clipPath
+            clipPath.append("path")
+                .datum(data)
+                .attr("d", area);
+
+            // 4. Add the giant text and apply the clip path
+            svg.append("text")
+                .attr("class", "country-text")
+                .attr("x", width / 2)
+                .attr("y", height / 2 + 70) // Adjust vertical centering
+                .attr("clip-path", "url(#text-clipper)") // This is the magic!
+                .text(countryName);
+            
+            // --- DATA LINES (drawn on top of everything) ---
+            const lineGenerator = d3.line()
+                .x(d => xScale(d.year))
+                .y(d => yScale(d.gdp))
+                .curve(d3.curveMonotoneX); // Smooth the line
+
+            // White outline (drawn first, thicker)
+            svg.append("path")
+                .datum(data)
+                .attr("class", "line-outline")
+                .attr("d", lineGenerator);
+
+            // Dark grey main line (drawn on top, thinner)
+            svg.append("path")
+                .datum(data)
+                .attr("class", "line")
+                .attr("d", lineGenerator);
+        }
+        
+        // --- 4. EVENT LISTENERS ---
+        window.addEventListener('keydown', (event) => {
+            // Hide placeholder and show chart on first keypress
+            if (placeholder.classed('hidden') === false) {
+                placeholder.classed('hidden', true);
+                container.classed('hidden', false).classed('visible', true);
+            }
+
+            if (event.key === 'Backspace') {
+                currentCountryName = currentCountryName.slice(0, -1);
+            } else if (event.key.length === 1 && event.key.match(/[a-z\s]/i)) {
+                // Allow letters and spaces
+                currentCountryName += event.key;
+            }
+
+            // Redraw on every valid key press
+            drawChart(currentCountryName.toUpperCase());
+            
+            // If input is empty, go back to placeholder
+            if (currentCountryName.length === 0) {
+                 placeholder.classed('hidden', false);
+                 container.classed('hidden', true).classed('visible', false);
+            }
+        });
+
+        // Handle window resize
+        window.addEventListener('resize', () => {
+            if (currentCountryName.length > 0) {
+                setupChart();
+                drawChart(currentCountryName.toUpperCase());
+            }
+        });
+
+        // Initial setup
+        container.classed('hidden', true);
+    </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- overhaul `gdp_clipmask.html` with interactive clip‑mask visualization
- link the clip mask demo from the "Cool Visualizations" page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68446496b858832cbf2c7b5ddb8a203f