### PR TITLE
Fix image list for home page

### DIFF
--- a/.github/workflows/update_image_list.yml
+++ b/.github/workflows/update_image_list.yml
@@ -1,0 +1,40 @@
+name: Update Image List
+
+on:
+  schedule:
+    - cron: '0 1 * * *'  # Runs daily at 01:00 UTC
+  workflow_dispatch:
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: pip install Pillow
+
+      - name: Generate image list
+        run: python scripts/generate_image_list.py
+
+      - name: Commit and push if changes
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          if ! git diff --quiet scripts/image_list.json; then
+            echo "Changes found in image list. Committing and pushing."
+            git add scripts/image_list.json
+            git commit -m "Automated update of image list"
+            git push
+          else
+            echo "No changes to image list."
+          fi
+

--- a/README.md
+++ b/README.md
@@ -66,11 +66,11 @@ git push origin main
 
 The homepage features an image carousel that displays images from the `images/` folder.
 
-When you add new images to the `images/` folder or remove existing ones, you need to update the list of images used by the homepage. To do this, run the following command from the root of the repository:
+Whenever images are added or removed, a GitHub Actions workflow automatically updates `scripts/image_list.json` with the current contents of the folder. You can also update the file manually by running:
 ```bash
 python scripts/generate_image_list.py
 ```
-This will update the `scripts/image_list.json` file, which is used by the homepage to find the images. After running the script, commit the changes to `scripts/image_list.json` along with your new image files.
+The JSON file is used by the homepage to choose a random image.
 
 ## Contact
 

--- a/index.html
+++ b/index.html
@@ -76,7 +76,7 @@ ul {
 
 <a href="links.html" style="text-decoration: none; color: inherit;">
   <div id="image-container">
-    <img id="profile-image">
+    <img id="profile-image" alt="Profile photo" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==">
   </div>
 </a>
 <h1 style="text-align: center;">

--- a/scripts/image_list.json
+++ b/scripts/image_list.json
@@ -1,8 +1,7 @@
 [
   "images/web_5.png",
-  "images/web_3.png",
-  "images/web_8.png",
   "images/web_6.png",
+  "images/web_3.png",
   "images/web_9.png",
-  "images/web_4.png"
+  "images/web_8.png"
 ]


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow to auto-generate `image_list.json`
- fix missing attributes on `profile-image` tag
- regenerate `image_list.json`
- mention automation in README

## Testing
- `html5validator --root . --files index.html`

------
https://chatgpt.com/codex/tasks/task_e_6848555efbc4832c86bec9d9f34fbdc6