### PR TITLE
Improve math sequence visualizations

### DIFF
--- a/collatz_path.html
+++ b/collatz_path.html
@@ -13,7 +13,7 @@
       align-items: center;
       height: 100vh;
     }
-    canvas { border:1px solid #555; }
+    canvas { width:600px; height:400px; }
   </style>
 </head>
 <body>
@@ -21,19 +21,29 @@
   <script>
     const canvas=document.getElementById('canvas');
     const ctx=canvas.getContext('2d');
-    ctx.translate(20,canvas.height-20);
+    const dpr=window.devicePixelRatio||1;
+    canvas.width=600*dpr;
+    canvas.height=400*dpr;
+    canvas.style.width='600px';
+    canvas.style.height='400px';
+    ctx.scale(dpr,dpr);
+    ctx.translate(20,canvas.height/dpr-20);
     ctx.strokeStyle='white';
+    ctx.font='16px Courier New';
+    ctx.textAlign='center';
     let n=Math.floor(Math.random()*50)+10;
     let step=0;
     document.title=`Collatz Path from ${n}`;
     ctx.beginPath();
     ctx.moveTo(0,-n);
+    ctx.fillText(n,0,-n);
     function next(){
-      if(n===1) return;
+      if(n===1){ctx.stroke();return;}
       n=n%2===0?n/2:3*n+1;
       step++;
-      ctx.lineTo(step*10,-n);
+      ctx.lineTo(step*20,-n);
       ctx.stroke();
+      ctx.fillText(n,step*20,-n);
       setTimeout(next,300);
     }
     next();

--- a/fibonacci_spiral.html
+++ b/fibonacci_spiral.html
@@ -13,7 +13,7 @@
       align-items: center;
       height: 100vh;
     }
-    canvas { border:1px solid #555; }
+    canvas { width:600px; height:600px; }
   </style>
 </head>
 <body>
@@ -21,21 +21,39 @@
   <script>
     const canvas=document.getElementById('canvas');
     const ctx=canvas.getContext('2d');
-    ctx.translate(canvas.width/2, canvas.height/2);
+    const dpr=window.devicePixelRatio||1;
+    canvas.width=600*dpr;
+    canvas.height=600*dpr;
+    canvas.style.width='600px';
+    canvas.style.height='600px';
+    ctx.scale(dpr,dpr);
+    ctx.translate(300,300);
     ctx.strokeStyle='white';
+    ctx.lineWidth=2;
+    ctx.font='16px Courier New';
+    ctx.textAlign='center';
+    ctx.textBaseline='middle';
     const phi=(1+Math.sqrt(5))/2;
+    const fib=[1,1];
     let angle=0;
-    let scale=2;
+    let segment=0;
+    const maxSeg=10;
     ctx.beginPath();
     ctx.moveTo(0,0);
+    ctx.fillText('1',0,0);
     function draw(){
-      const r=Math.pow(phi,angle/(Math.PI/2))*scale;
+      const r=Math.pow(phi,angle/(Math.PI/2))*15;
       const x=r*Math.cos(angle);
       const y=r*Math.sin(angle);
       ctx.lineTo(x,y);
       ctx.stroke();
-      angle+=0.05;
-      if(angle<6*Math.PI) requestAnimationFrame(draw);
+      if(angle>=(segment+1)*Math.PI/2 && segment<maxSeg){
+        segment++;
+        if(!fib[segment]) fib[segment]=fib[segment-1]+fib[segment-2];
+        ctx.fillText(fib[segment],x,y);
+      }
+      angle+=0.02;
+      if(segment<maxSeg) requestAnimationFrame(draw);
     }
     draw();
   </script>

--- a/pascal_triangle.html
+++ b/pascal_triangle.html
@@ -13,7 +13,7 @@
       align-items: center;
       height: 100vh;
     }
-    canvas { border:1px solid #555; }
+    canvas { width:500px; height:500px; }
   </style>
 </head>
 <body>
@@ -21,8 +21,15 @@
   <script>
     const canvas=document.getElementById('canvas');
     const ctx=canvas.getContext('2d');
-    ctx.translate(canvas.width/2,20);
+    const dpr=window.devicePixelRatio||1;
+    canvas.width=500*dpr;
+    canvas.height=500*dpr;
+    canvas.style.width='500px';
+    canvas.style.height='500px';
+    ctx.scale(dpr,dpr);
+    ctx.translate(250,20);
     ctx.fillStyle='white';
+    ctx.font='18px Courier New';
     const rows=15;
     const tri=[[1]];
     let r=0;

--- a/prime_spiral.html
+++ b/prime_spiral.html
@@ -13,7 +13,7 @@
       align-items: center;
       height: 100vh;
     }
-    canvas { border:1px solid #555; }
+    canvas { width:500px; height:500px; }
   </style>
 </head>
 <body>
@@ -21,10 +21,17 @@
   <script>
     const canvas=document.getElementById('canvas');
     const ctx=canvas.getContext('2d');
-    const size=4;
-    const n=125;
-    canvas.width=size*n;
-    canvas.height=size*n;
+    const dpr=window.devicePixelRatio||1;
+    const cell=20;
+    const n=21;
+    canvas.width=cell*n*dpr;
+    canvas.height=cell*n*dpr;
+    canvas.style.width=cell*n+'px';
+    canvas.style.height=cell*n+'px';
+    ctx.scale(dpr,dpr);
+    ctx.font='12px Courier New';
+    ctx.textAlign='center';
+    ctx.textBaseline='middle';
     let x=Math.floor(n/2),y=x;
     let dx=1,dy=0;
     let segmentLength=1,segmentPassed=0,segmentStep=0;
@@ -36,10 +43,10 @@
     }
     function step(){
       if(val>n*n) return;
-      if(isPrime(val)){
-        ctx.fillStyle='white';
-        ctx.fillRect(x*size,y*size,size,size);
-      }
+      ctx.fillStyle=isPrime(val)?'white':'#222';
+      ctx.fillRect(x*cell,y*cell,cell,cell);
+      ctx.fillStyle=isPrime(val)?'black':'white';
+      ctx.fillText(val,x*cell+cell/2,y*cell+cell/2);
       x+=dx; y+=dy; val++; segmentPassed++;
       if(segmentPassed===segmentLength){
         segmentPassed=0;

--- a/sierpinski_triangle.html
+++ b/sierpinski_triangle.html
@@ -13,7 +13,7 @@
       align-items: center;
       height: 100vh;
     }
-    canvas { border:1px solid #555; }
+    canvas { width:500px; height:500px; }
   </style>
 </head>
 <body>
@@ -21,15 +21,32 @@
   <script>
     const canvas=document.getElementById('canvas');
     const ctx=canvas.getContext('2d');
+    const dpr=window.devicePixelRatio||1;
+    canvas.width=500*dpr;
+    canvas.height=500*dpr;
+    canvas.style.width='500px';
+    canvas.style.height='500px';
+    ctx.scale(dpr,dpr);
     const verts=[[250,20],[20,480],[480,480]];
     let point=[250,250];
+    let count=0;
     ctx.fillStyle='white';
+    ctx.font='16px Courier New';
+    function drawCount(){
+      ctx.fillStyle='black';
+      ctx.fillRect(0,0,90,24);
+      ctx.fillStyle='white';
+      ctx.fillText(count,45,16);
+    }
     function step(){
       const v=verts[Math.floor(Math.random()*3)];
       point=[(point[0]+v[0])/2,(point[1]+v[1])/2];
       ctx.fillRect(point[0],point[1],1,1);
+      count++;
+      if(count%100===0) drawCount();
       requestAnimationFrame(step);
     }
+    drawCount();
     step();
   </script>
   <script src="scripts/keyboard_nav.js"></script>


### PR DESCRIPTION
## Summary
- modernize sequence canvases by scaling for device pixel ratio
- show numbers in Fibonacci spiral, Pascal triangle, prime spiral, Collatz path, and Sierpinski triangle
- remove distracting borders and tweak fonts

## Testing
- `npx -y htmlhint fibonacci_spiral.html pascal_triangle.html prime_spiral.html collatz_path.html sierpinski_triangle.html`

------
https://chatgpt.com/codex/tasks/task_e_6849c3a4f090832cbf4cf297f2c4d061