### PR TITLE
Enhance prime spiral animation

### DIFF
--- a/prime_spiral.html
+++ b/prime_spiral.html
@@ -17,46 +17,67 @@
   </style>
 </head>
 <body>
-  <canvas id="canvas" width="500" height="500"></canvas>
+  <canvas id="canvas" width="1000" height="1000"></canvas>
   <script>
-    const canvas=document.getElementById('canvas');
-    const ctx=canvas.getContext('2d');
-    const dpr=window.devicePixelRatio||1;
-    const cell=8;
-    const n=101;
-    canvas.width=cell*n*dpr;
-    canvas.height=cell*n*dpr;
-    canvas.style.width=cell*n+'px';
-    canvas.style.height=cell*n+'px';
-    ctx.scale(dpr,dpr);
-    ctx.font='12px Courier New';
-    ctx.textAlign='center';
-    ctx.textBaseline='middle';
-    let x=Math.floor(n/2),y=x;
-    let dx=1,dy=0;
-    let segmentLength=1,segmentPassed=0,segmentStep=0;
-    let val=1;
-    function isPrime(num){
-      if(num<2) return false;
-      for(let i=2;i*i<=num;i++) if(num%i===0) return false;
-      return true;
-    }
-    function step(){
-      if(val>n*n) return;
-      const prime=isPrime(val);
-      ctx.fillStyle=prime?'#ffd700':'#444';
-      ctx.beginPath();
-      ctx.arc(x*cell+cell/2,y*cell+cell/2,cell/2-1,0,Math.PI*2);
-      ctx.fill();
-      if(val<100){
-        ctx.fillStyle=prime?'black':'white';
-        ctx.fillText(val,x*cell+cell/2,y*cell+cell/2);
+    const canvas = document.getElementById('canvas');
+    const ctx = canvas.getContext('2d');
+    const dpr = window.devicePixelRatio || 1;
+
+    const LIMIT = 1000000; // draw up to one million
+    const n = Math.ceil(Math.sqrt(LIMIT));
+    const cell = 2; // base cell size
+
+    canvas.width = n * cell * dpr;
+    canvas.height = n * cell * dpr;
+    canvas.style.width = n * cell + 'px';
+    canvas.style.height = n * cell + 'px';
+    canvas.style.transformOrigin = 'center center';
+
+    ctx.scale(dpr, dpr);
+    ctx.font = (cell * 0.8) + 'px Courier New';
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+
+    // Precompute primes using sieve
+    const primes = new Uint8Array(LIMIT + 1);
+    primes.fill(1, 2);
+    for (let i = 2; i * i <= LIMIT; i++) {
+      if (primes[i]) {
+        for (let j = i * i; j <= LIMIT; j += i) primes[j] = 0;
       }
-      x+=dx; y+=dy; val++; segmentPassed++;
-      if(segmentPassed===segmentLength){
-        segmentPassed=0;
-        const t=dx; dx=-dy; dy=t;
-        segmentStep++; if(segmentStep%2===0) segmentLength++;
+    }
+
+    let x = Math.floor(n / 2), y = x;
+    let dx = 1, dy = 0;
+    let segmentLength = 1, segmentPassed = 0, segmentStep = 0;
+    let val = 1;
+    let stepsPerFrame = 1;
+    let zoom = 20;
+    canvas.style.transform = 'scale(' + zoom + ')';
+
+    function step() {
+      for (let s = 0; s < stepsPerFrame; s++) {
+        if (val > LIMIT) return;
+        const prime = primes[val];
+        ctx.fillStyle = prime ? '#ffd700' : '#444';
+        ctx.beginPath();
+        ctx.arc(x * cell + cell / 2, y * cell + cell / 2, cell / 2 - 0.2, 0, Math.PI * 2);
+        ctx.fill();
+        if (val < 100) {
+          ctx.fillStyle = prime ? 'black' : 'white';
+          ctx.fillText(val, x * cell + cell / 2, y * cell + cell / 2 + 0.1);
+        }
+        x += dx; y += dy; val++; segmentPassed++;
+        if (segmentPassed === segmentLength) {
+          segmentPassed = 0;
+          const t = dx; dx = -dy; dy = t;
+          segmentStep++; if (segmentStep % 2 === 0) segmentLength++;
+        }
+      }
+      if (stepsPerFrame < 100) stepsPerFrame += 0.05; // accelerate
+      if (zoom > 1 && val % 1000 === 0) {
+        zoom *= 0.98;
+        canvas.style.transform = 'scale(' + zoom + ')';
       }
       requestAnimationFrame(step);
     }


### PR DESCRIPTION
## Summary
- precompute primes to avoid recalculation
- animate to one million numbers with accelerating speed
- zoom canvas out gradually so numbers remain visible
- ensure text fits inside circles

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6849c90756b0832cb9a3907dd7c76a30