### PR TITLE
Fix audio visualizer initialization

### DIFF
--- a/scripts/audio_visualizers.js
+++ b/scripts/audio_visualizers.js
@@ -4,6 +4,7 @@
 let audioCtx, analyser, freqData, timeData;
 const canvases = [];
 const ctxs = [];
+let started = false;
 
 function initAudio() {
   if (audioCtx) return Promise.resolve();
@@ -27,10 +28,20 @@ function setupCanvases() {
 }
 
 function start() {
+  if (started) return;
+  started = true;
+  const btn = document.getElementById('start');
+  if (btn) btn.disabled = true;
   initAudio().then(() => {
+    if (audioCtx.state === 'suspended') {
+      return audioCtx.resume();
+    }
+  }).then(() => {
     setupCanvases();
     requestAnimationFrame(draw);
   }).catch(err => {
+    started = false;
+    if (btn) btn.disabled = false;
     alert('Microphone access denied');
   });
 }

--- a/scripts/version.js
+++ b/scripts/version.js
@@ -1,6 +1,6 @@
 // This file is automatically updated by the pre-commit hook
 window.APP_VERSION = {
-  commit: "451c992",
-  date: "2025-06-16T00:07:47Z",
-  timestamp: 1750032467000
+  commit: "e59d69f",
+  date: "2025-06-16T00:24:33Z",
+  timestamp: 1750033473000
 };


### PR DESCRIPTION
## Summary
- prevent multiple audio visualizer initializations
- resume AudioContext when required
- disable the start button after activation
- update version metadata

## Testing
- `./update-version.sh`

------
https://chatgpt.com/codex/tasks/task_e_684f63f1da48832cb152670638048c86