### PR TITLE
Fix Tamil flashcards rendering issue

### DIFF
--- a/scripts/tamil-flashcards.js
+++ b/scripts/tamil-flashcards.js
@@ -213,11 +213,11 @@ function TamilFlashcards() {
             <div className="text-2xl text-yellow-300">{current.translit}</div>
           )}
           {showWord && (
-            <>
+            <React.Fragment>
               <div className="text-xl text-green-300 mt-1">{current.word}</div>
               <div className="text-sm text-blue-300">{current.wordTranslit}</div>
               <div className="text-sm text-blue-300">{current.english}</div>
-            </>
+            </React.Fragment>
           )}
         </div>
       </div>


### PR DESCRIPTION
## Summary
- fix JSX fragment syntax for Tamil flashcards

## Testing
- `node -e "console.log('no tests specified')"`


------
https://chatgpt.com/codex/tasks/task_e_68542426d810832cbe5bd4c05f365b0b