### PR TITLE
Improve wealth inequality animation

### DIFF
--- a/scripts/wealth_inequality.js
+++ b/scripts/wealth_inequality.js
@@ -1,9 +1,9 @@
 document.addEventListener('DOMContentLoaded', function() {
   const data = [
-    { label: 'Top 0.1%', value: 20 },
-    { label: 'Next 0.9%', value: 12 },
-    { label: 'Next 9%', value: 40 },
-    { label: 'Bottom 90%', value: 28 }
+    { label: 'Top 0.1%', value: 20, color: '#ff6384' },
+    { label: 'Next 0.9%', value: 12, color: '#ff9f40' },
+    { label: 'Next 9%', value: 40, color: '#36a2eb' },
+    { label: 'Bottom 90%', value: 28, color: '#4bc0c0' }
   ];
 
   const chart = document.getElementById('chart');
@@ -14,6 +14,7 @@ document.addEventListener('DOMContentLoaded', function() {
     const bar = document.createElement('div');
     bar.className = 'bar';
     bar.dataset.value = d.value;
+    bar.style.backgroundColor = d.color;
 
     const val = document.createElement('div');
     val.className = 'value';
@@ -31,13 +32,13 @@ document.addEventListener('DOMContentLoaded', function() {
 
   anime({
     targets: '.bar',
-    height: el => el.dataset.value + '%',
-    easing: 'easeOutExpo',
+    scaleY: el => el.dataset.value / 100,
+    easing: 'easeOutElastic(1, .8)',
     duration: 2000,
     delay: anime.stagger(300),
     update: function() {
       document.querySelectorAll('.bar').forEach(bar => {
-        const v = Math.round(parseFloat(bar.style.height));
+        const v = Math.round(parseFloat(bar.dataset.value));
         const span = bar.querySelector('.value');
         if (span) span.textContent = v + '%';
       });

--- a/wealth_inequality.html
+++ b/wealth_inequality.html
@@ -22,12 +22,16 @@
       margin: 0 10px;
       text-align: center;
       position: relative;
+      height: 100%;
     }
     .bar {
-      background: #87CEFA;
       width: 100%;
-      height: 0;
+      height: 100%;
+      transform: scaleY(0);
+      transform-origin: bottom;
+      border-radius: 4px 4px 0 0;
       position: relative;
+      box-shadow: 0 0 10px rgba(255, 255, 255, 0.3);
     }
     .bar .value {
       position: absolute;


### PR DESCRIPTION
## Summary
- smooth vertical bar animation for the wealth inequality visualization
- add colors for each wealth bracket
- polish styles for the bar chart

## Testing
- `python -m py_compile scripts/generate_image_list.py`


------
https://chatgpt.com/codex/tasks/task_e_6855740905b8832cbe41944e9dc2425f