### PR TITLE
Fix search overlay highlight visibility

### DIFF
--- a/scripts/site_search.js
+++ b/scripts/site_search.js
@@ -76,7 +76,7 @@ function createSearchOverlay() {
 
   const styleTag = document.createElement('style');
   styleTag.textContent = `
-    #search-overlay li.active {background:#00246B;color:#fff;}
+    #search-overlay li.active {background:#C41E3A;color:#fff;}
     #search-overlay li.active a {color:#fff;text-decoration:none;}
     #search-overlay mark {background:#FFEB3B;color:inherit;padding:0;}
   `;


### PR DESCRIPTION
## Summary
- adjust spotlight selection color in `site_search.js`

## Testing
- `n/a`

------
https://chatgpt.com/codex/tasks/task_e_685771c0a614832ca6eb0eceaa13a0a1