### PR TITLE
Fix wealth inequality visualization

### DIFF
--- a/scripts/wealth_inequality.js
+++ b/scripts/wealth_inequality.js
@@ -1,9 +1,10 @@
 document.addEventListener('DOMContentLoaded', function() {
+  // Colors progress from dark red (most wealth) to light yellow (least wealth)
   const data = [
-    { label: 'Top 0.1%', value: 20, color: '#ff6384' },
-    { label: 'Next 0.9%', value: 12, color: '#ff9f40' },
-    { label: 'Next 9%', value: 40, color: '#36a2eb' },
-    { label: 'Bottom 90%', value: 28, color: '#4bc0c0' }
+    { label: 'Top 0.1%', value: 20, color: '#8b0000' },
+    { label: 'Next 0.9%', value: 12, color: '#d7301f' },
+    { label: 'Next 9%',   value: 40, color: '#fc8d59' },
+    { label: 'Bottom 90%', value: 28, color: '#fee08b' }
   ];
 
   const chart = document.getElementById('chart');
@@ -13,13 +14,18 @@ document.addEventListener('DOMContentLoaded', function() {
 
     const bar = document.createElement('div');
     bar.className = 'bar';
-    bar.dataset.value = d.value;
-    bar.style.backgroundColor = d.color;
+
+    const fill = document.createElement('div');
+    fill.className = 'bar-fill';
+    fill.dataset.value = d.value;
+    fill.style.backgroundColor = d.color;
+    bar.appendChild(fill);
 
     const val = document.createElement('div');
     val.className = 'value';
     val.textContent = '0%';
     bar.appendChild(val);
+
     container.appendChild(bar);
 
     const label = document.createElement('div');
@@ -31,15 +37,15 @@ document.addEventListener('DOMContentLoaded', function() {
   });
 
   anime({
-    targets: '.bar',
+    targets: '.bar-fill',
     scaleY: el => el.dataset.value / 100,
     easing: 'easeOutElastic(1, .8)',
     duration: 2000,
     delay: anime.stagger(300),
-    update: function() {
-      document.querySelectorAll('.bar').forEach(bar => {
-        const v = Math.round(parseFloat(bar.dataset.value));
-        const span = bar.querySelector('.value');
+    complete: function() {
+      document.querySelectorAll('.bar-fill').forEach(fill => {
+        const v = Math.round(parseFloat(fill.dataset.value));
+        const span = fill.parentNode.querySelector('.value');
         if (span) span.textContent = v + '%';
       });
     }

--- a/wealth_inequality.html
+++ b/wealth_inequality.html
@@ -27,10 +27,17 @@
     .bar {
       width: 100%;
       height: 100%;
+      position: relative;
+    }
+    .bar-fill {
+      position: absolute;
+      bottom: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
       transform: scaleY(0);
       transform-origin: bottom;
       border-radius: 4px 4px 0 0;
-      position: relative;
       box-shadow: 0 0 10px rgba(255, 255, 255, 0.3);
     }
     .bar .value {
@@ -38,7 +45,8 @@
       bottom: 100%;
       left: 50%;
       transform: translateX(-50%);
-      font-size: 0.9em;
+      font-size: 1em;
+      font-weight: bold;
       margin-bottom: 5px;
     }
     .label {
@@ -48,7 +56,7 @@
 </head>
 <body>
   <h1>Wealth Distribution in the United States</h1>
-  <p>This animation shows how a small fraction of households hold a large share of the nation's wealth.</p>
+  <p>This animation shows how a small fraction of households hold a large share of the nation's wealth. Bar colors range from dark red (most wealth) to pale yellow (least wealth).</p>
   <div id="chart"></div>
   <hr>
   <p><a href="cool_visualizations.html">&larr; Back to Visualizations</a></p>


### PR DESCRIPTION
## Summary
- improve the color scheme of the wealth inequality bars
- make bars animate smoothly without distorting the values
- clarify how colors represent share of wealth

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685771e89b38832c9db5e8d908c6867d