### PR TITLE
Show numeric value for dice roll

### DIFF
--- a/scripts/random_generator.js
+++ b/scripts/random_generator.js
@@ -18,7 +18,7 @@ document.addEventListener('DOMContentLoaded', function() {
     coinEl.textContent = coin;
 
     const diceRoll = Math.floor(Math.random() * 6);
-    diceEl.textContent = diceFaces[diceRoll];
+    diceEl.textContent = diceFaces[diceRoll] + ' (' + (diceRoll + 1) + ')';
 
     const suit = suits[Math.floor(Math.random() * suits.length)];
     const value = values[Math.floor(Math.random() * values.length)];


### PR DESCRIPTION
## Summary
- include numeric result in dice display so the value is easier to see

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6857725f4d00832c96e49ddab8efd4a4