### PR TITLE
Add crypto prices page

### DIFF
--- a/crypto_prices.html
+++ b/crypto_prices.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Crypto Prices - Karthik Balasubramanian</title>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <style>
+    body {
+      background-color: #000;
+      color: #fff;
+      font-family: "Courier New", Courier, monospace;
+      margin: 40px;
+    }
+    h1 {
+      color: #fbbf24;
+      text-align: center;
+    }
+    .price {
+      font-size: 2em;
+      margin: 20px 0;
+      text-align: center;
+    }
+    a {
+      color: #60a5fa;
+    }
+  </style>
+</head>
+<body>
+  <h1>BTC and ETH Prices (USD)</h1>
+  <div class="price" id="btc-price">Loading BTC price...</div>
+  <div class="price" id="eth-price">Loading ETH price...</div>
+  <p style="text-align:center;"><a href="index.html">&#8592; Back to Home</a></p>
+  <script src="scripts/crypto_prices.js"></script>
+  <script src="scripts/keyboard_nav.js"></script>
+  <script src="scripts/site_search.js"></script>
+</body>
+</html>

--- a/scripts/crypto_prices.js
+++ b/scripts/crypto_prices.js
@@ -1,0 +1,13 @@
+(async function() {
+  try {
+    const response = await fetch('https://api.coingecko.com/api/v3/simple/price?ids=bitcoin,ethereum&vs_currencies=usd');
+    if (!response.ok) throw new Error('Network response was not ok');
+    const data = await response.json();
+    document.getElementById('btc-price').textContent = 'BTC: $' + data.bitcoin.usd.toLocaleString();
+    document.getElementById('eth-price').textContent = 'ETH: $' + data.ethereum.usd.toLocaleString();
+  } catch (err) {
+    document.getElementById('btc-price').textContent = 'Failed to load prices';
+    document.getElementById('eth-price').textContent = '';
+    console.error(err);
+  }
+})();

--- a/search_index.json
+++ b/search_index.json
@@ -253,5 +253,10 @@
     "title": "Wealth Inequality Animation",
     "url": "wealth_inequality.html",
     "text": "Wealth Distribution in the United States"
+  },
+  {
+    "title": "Crypto Prices",
+    "url": "crypto_prices.html",
+    "text": "Live BTC and ETH prices"
   }
 ]

--- a/sitemap.html
+++ b/sitemap.html
@@ -77,6 +77,7 @@
         <a href="whales.html">Whale Song Visualizer</a>
         <a href="wealth_inequality.html">Wealth Inequality Animation</a>
         <a href="cool_stuff.html">Cool Stuff (External Links)</a>
+        <a href="crypto_prices.html">Crypto Prices</a>
     </div>
 <script src="scripts/keyboard_nav.js"></script>
   <script src="scripts/site_search.js"></script>


### PR DESCRIPTION
## Summary
- add new `crypto_prices.html` page for BTC and ETH
- fetch prices from CoinGecko in `scripts/crypto_prices.js`
- update sitemap and search index

## Testing
- `python -m json.tool search_index.json`

------
https://chatgpt.com/codex/tasks/task_e_685834f02b64832cabb40e96449cb91c