### PR TITLE
Add browser data viewer page

### DIFF
--- a/helpful_tools.html
+++ b/helpful_tools.html
@@ -32,6 +32,9 @@
             <div class="link-card">
                 <a href="time_tax.html">Time Tax Calculator</a>
             </div>
+            <div class="link-card">
+                <a href="user_info.html">Browser Data Viewer</a>
+            </div>
         </div>
     </div>
     <div class="section">

--- a/scripts/user_info.js
+++ b/scripts/user_info.js
@@ -1,0 +1,39 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const list = document.getElementById('info-list');
+  const add = (label, value) => {
+    const li = document.createElement('li');
+    li.textContent = `${label}: ${value}`;
+    list.appendChild(li);
+  };
+
+  add('User Agent', navigator.userAgent);
+  add('Platform', navigator.platform || 'N/A');
+  add('Browser Language', navigator.language);
+  add('Languages', navigator.languages ? navigator.languages.join(', ') : 'N/A');
+  add('Cookies Enabled', navigator.cookieEnabled);
+  add('Do Not Track', navigator.doNotTrack || 'N/A');
+  add('Hardware Threads', navigator.hardwareConcurrency || 'N/A');
+  add('Device Memory', navigator.deviceMemory ? navigator.deviceMemory + ' GB' : 'N/A');
+  add('Screen Resolution', `${screen.width}x${screen.height}`);
+  add('Color Depth', screen.colorDepth);
+  add('Pixel Ratio', window.devicePixelRatio);
+  add('Window Size', `${window.innerWidth}x${window.innerHeight}`);
+  add('Orientation', screen.orientation ? screen.orientation.type : 'N/A');
+  add('Time Zone', Intl.DateTimeFormat().resolvedOptions().timeZone);
+  add('Local Time', new Date().toString());
+  add('Referrer', document.referrer || 'N/A');
+  add('URL', location.href);
+  add('Geolocation Supported', navigator.geolocation ? 'Yes' : 'No');
+
+  try {
+    fetch('https://api.ipify.org?format=json')
+      .then(r => r.json())
+      .then(d => add('IP Address', d.ip))
+      .catch(() => add('IP Address', 'Unavailable'));
+  } catch (e) {
+    add('IP Address', 'Unavailable');
+  }
+
+  const isMobile = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
+  add('Device Type', isMobile ? 'Mobile' : 'Desktop');
+});

--- a/user_info.html
+++ b/user_info.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Your Data - Karthik Balasubramanian</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body class="links-dark-theme">
+
+<div class="content-cell">
+    <div class="section">
+        <h1>Your Browser Data</h1>
+        <p>This page lists information that websites can often gather from your browser.</p>
+        <ul id="info-list"></ul>
+    </div>
+</div>
+
+<script src="scripts/user_info.js"></script>
+<script src="scripts/keyboard_nav.js"></script>
+<script src="scripts/site_search.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- show browser data to demonstrate what information websites may access
- link to the new viewer from the Helpful Tools page

## Testing
- `curl -s https://api.ipify.org?format=json | head`


------
https://chatgpt.com/codex/tasks/task_e_6859a6de3020832c9eea6083172105ab