### PR TITLE
Enhance world clock with rates and mobile search

### DIFF
--- a/helpful_tools.html
+++ b/helpful_tools.html
@@ -35,6 +35,9 @@
             <div class="link-card">
                 <a href="user_info.html">Browser Data Viewer</a>
             </div>
+            <div class="link-card">
+                <a href="world_clock.html">World Clock & Rates</a>
+            </div>
         </div>
     </div>
     <div class="section">

--- a/scripts/site_search.js
+++ b/scripts/site_search.js
@@ -162,3 +162,35 @@ document.addEventListener('keydown', e => {
     openSearch();
   }
 });
+
+// Add mobile search button
+function createMobileButton(){
+  const btn = document.createElement('button');
+  btn.id = 'mobile-search-btn';
+  btn.textContent = '🔍';
+  Object.assign(btn.style, {
+    position: 'fixed',
+    bottom: '20px',
+    right: '20px',
+    width: '48px',
+    height: '48px',
+    borderRadius: '50%',
+    border: 'none',
+    background: '#C41E3A',
+    color: '#fff',
+    fontSize: '24px',
+    zIndex: '999',
+    display: 'none'
+  });
+  btn.addEventListener('click', openSearch);
+  document.body.appendChild(btn);
+
+  const mq = window.matchMedia('(max-width: 600px)');
+  function update(){
+    btn.style.display = mq.matches ? 'block' : 'none';
+  }
+  mq.addListener(update);
+  update();
+}
+
+document.addEventListener('DOMContentLoaded', createMobileButton);

--- a/world_clock.html
+++ b/world_clock.html
@@ -44,6 +44,14 @@
     <li><span class="label">NRT</span><span id="nrt"></span></li>
     <li><span class="label">PER</span><span id="per"></span></li>
   </ul>
+  <h2 style="margin-top:30px;">Exchange Rates per USD</h2>
+  <ul id="rates">
+    <li><span class="label">GBP</span><span id="rate-gbp"></span></li>
+    <li><span class="label">KES</span><span id="rate-kes"></span></li>
+    <li><span class="label">INR</span><span id="rate-inr"></span></li>
+    <li><span class="label">JPY</span><span id="rate-jpy"></span></li>
+    <li><span class="label">AUD</span><span id="rate-aud"></span></li>
+  </ul>
   <script>
     const zones = {
       hnl: 'Pacific/Honolulu',
@@ -70,6 +78,29 @@
     }
     update();
     setInterval(update, 1000);
+
+    const rateElems = {
+      GBP: document.getElementById('rate-gbp'),
+      KES: document.getElementById('rate-kes'),
+      INR: document.getElementById('rate-inr'),
+      JPY: document.getElementById('rate-jpy'),
+      AUD: document.getElementById('rate-aud')
+    };
+
+    function updateRates(){
+      fetch('https://open.er-api.com/v6/latest/USD')
+        .then(r => r.json())
+        .then(data => {
+          const rates = data.rates;
+          for(const code in rateElems){
+            const val = rates[code];
+            if(val){
+              rateElems[code].textContent = val.toFixed(2);
+            }
+          }
+        });
+    }
+    updateRates();
   </script>
   <script src="scripts/keyboard_nav.js"></script>
   <script src="scripts/site_search.js"></script>


### PR DESCRIPTION
## Summary
- show currency exchange rates alongside world times
- link world clock from the Helpful Tools page
- add floating search button for Spotlight on small screens

## Testing
- `node -e "require('./scripts/site_search.js');"` *(fails: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_685b4be6fc84832caa8a8bf4c1561ec9