### PR TITLE
Improve dice roller

### DIFF
--- a/dice_roll.html
+++ b/dice_roll.html
@@ -16,6 +16,7 @@
       flex-direction: column;
       align-items: center;
       justify-content: center;
+      position: relative;
     }
     h1 {
       color: #fbbf24;
@@ -55,10 +56,37 @@
       background: #4b5563;
       border-color: #9ca3af;
     }
+
+    #sum {
+      position: absolute;
+      top: 10px;
+      right: 10px;
+      background: #1f2937;
+      border: 2px solid #374151;
+      border-radius: 8px;
+      padding: 8px 12px;
+      font-size: 1.2em;
+    }
+
+    @media (max-width: 600px) {
+      h1 {
+        font-size: 1.8em;
+      }
+      .dice-container {
+        gap: 20px;
+      }
+      .dice-box {
+        width: 120px;
+        height: 120px;
+        font-size: 3em;
+        padding: 20px;
+      }
+    }
   </style>
 </head>
 <body>
   <h1>Dice Roller</h1>
+  <div id="sum">Sum: 2</div>
   <div class="dice-container">
     <div class="dice-box" id="die1">⚀</div>
     <div class="dice-box" id="die2">⚀</div>

--- a/scripts/dice_roll.js
+++ b/scripts/dice_roll.js
@@ -1,6 +1,7 @@
 document.addEventListener('DOMContentLoaded', function() {
   const die1 = document.getElementById('die1');
   const die2 = document.getElementById('die2');
+  const sumEl = document.getElementById('sum');
   const button = document.getElementById('roll');
   const faces = ['\u2680','\u2681','\u2682','\u2683','\u2684','\u2685'];
 
@@ -9,6 +10,7 @@ document.addEventListener('DOMContentLoaded', function() {
     const d2 = Math.floor(Math.random() * 6);
     die1.textContent = faces[d1];
     die2.textContent = faces[d2];
+    sumEl.textContent = 'Sum: ' + (d1 + d2 + 2);
   }
 
   button.addEventListener('click', roll);


### PR DESCRIPTION
## Summary
- add absolute-positioned `sum` display
- responsive styles for smaller screens
- show dice sum in `dice_roll.js`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686221f00870832ca3e06470cd0f6e33