### PR TITLE
Improve dice roller visuals

### DIFF
--- a/dice_roll.html
+++ b/dice_roll.html
@@ -34,12 +34,12 @@
       border: 2px solid #374151;
       border-radius: 10px;
       padding: 40px;
-      width: 200px;
-      height: 200px;
+      width: 280px;
+      height: 280px;
       display: flex;
       align-items: center;
       justify-content: center;
-      font-size: 6em;
+      font-size: 8em;
     }
     .elegant-button {
       background: #374151;
@@ -59,13 +59,14 @@
 
     #sum {
       position: absolute;
-      top: 10px;
-      right: 10px;
+      top: 20px;
+      left: 50%;
+      transform: translateX(-50%);
       background: #1f2937;
       border: 2px solid #374151;
       border-radius: 8px;
-      padding: 8px 12px;
-      font-size: 1.2em;
+      padding: 12px 20px;
+      font-size: 2.5em;
     }
 
     @media (max-width: 600px) {
@@ -76,17 +77,20 @@
         gap: 20px;
       }
       .dice-box {
-        width: 120px;
-        height: 120px;
-        font-size: 3em;
+        width: 150px;
+        height: 150px;
+        font-size: 4.5em;
         padding: 20px;
+      }
+      #sum {
+        font-size: 1.5em;
       }
     }
   </style>
 </head>
 <body>
   <h1>Dice Roller</h1>
-  <div id="sum">Sum: 2</div>
+  <div id="sum">2</div>
   <div class="dice-container">
     <div class="dice-box" id="die1">⚀</div>
     <div class="dice-box" id="die2">⚀</div>

--- a/scripts/dice_roll.js
+++ b/scripts/dice_roll.js
@@ -10,7 +10,7 @@ document.addEventListener('DOMContentLoaded', function() {
     const d2 = Math.floor(Math.random() * 6);
     die1.textContent = faces[d1];
     die2.textContent = faces[d2];
-    sumEl.textContent = 'Sum: ' + (d1 + d2 + 2);
+    sumEl.textContent = d1 + d2 + 2;
   }
 
   button.addEventListener('click', roll);


### PR DESCRIPTION
## Summary
- enlarge dice and display the sum at the top center
- show only the numerical result

## Testing
- `git diff --cached --name-status`

------
https://chatgpt.com/codex/tasks/task_e_686227ecf97c832c98d5575124480b5a