### PR TITLE
Fix homepage image cycling

### DIFF
--- a/scripts/image_cycler.js
+++ b/scripts/image_cycler.js
@@ -6,7 +6,8 @@ function startImageCycle(imagePaths, imgElement, delayMs = 5000) {
   if (!imgElement || !Array.isArray(imagePaths) || imagePaths.length === 0) {
     return;
   }
-  let index = 0;
+  // Pick a random starting image so each page load shows something new
+  let index = Math.floor(Math.random() * imagePaths.length);
 
   function showNext() {
     imgElement.src = imagePaths[index];

--- a/scripts/version.js
+++ b/scripts/version.js
@@ -1,6 +1,6 @@
 // This file is automatically updated by the pre-commit hook
 window.APP_VERSION = {
-  commit: "6f67bac",
-  date: "2025-07-04T03:36:27Z",
-  timestamp: 1751600187000
+  commit: "b808e89",
+  date: "2025-07-04T03:48:00Z",
+  timestamp: 1751600880000
 };


### PR DESCRIPTION
## Summary
- start image rotation on a random photo to avoid always showing the same first picture
- update version metadata

## Testing
- `python scripts/generate_image_list.py` *(fails: Pillow not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68674db32d50832ca534643a38b152d2