### PR TITLE
Adjust versioning to avoid conflicts

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ python scripts/generate_image_list.py
 python scholar_scraper.py
 ```
 
-The `scripts/version.js` file is also updated automatically by a pre-commit hook (or by running `./update-version.sh`) to include the latest commit hash and timestamp.
+The `scripts/version.js` file is updated automatically by a pre-commit hook (or by running `./update-version.sh`). It now records only the current UTC date so unrelated commits on the same day don't conflict.
 
 ## Interactive Demos
 

--- a/scripts/version.js
+++ b/scripts/version.js
@@ -1,3 +1,5 @@
 // This file is automatically updated by the pre-commit hook
 window.APP_VERSION = {
+  commit: "20250704",
+  date: "2025-07-04"
 };

--- a/update-version.sh
+++ b/update-version.sh
@@ -3,21 +3,18 @@
 # This is a manual version update script for when the pre-commit hook isn't run
 # You can run this manually before committing by running ./update-version.sh
 
-# Get the current commit hash
-COMMIT_HASH=$(git rev-parse --short HEAD 2>/dev/null)
-if [ $? -ne 0 ]; then
-  # Not a git repository or git not available
-  COMMIT_HASH="manual-$(date +%s)"
-fi
+# Get the current date in YYYYMMDD format to use as the version
+TODAY=$(date -u +"%Y%m%d")
+# Separate human readable date value
+HUMAN_DATE=$(date -u +"%Y-%m-%d")
 
 # Update the version.js file
 cat > scripts/version.js << EOF
 // This file is automatically updated by the pre-commit hook
 window.APP_VERSION = {
-  commit: "${COMMIT_HASH}",
-  date: "$(date -u +"%Y-%m-%dT%H:%M:%SZ")",
-  timestamp: $(date +%s000)
+  commit: "${TODAY}",
+  date: "${HUMAN_DATE}"
 };
 EOF
 
-echo "Updated version.js with commit ${COMMIT_HASH}"
+echo "Updated version.js for ${HUMAN_DATE}"


### PR DESCRIPTION
## Summary
- store daily date information in `scripts/version.js`
- update README to describe the new versioning behavior
- revise `update-version.sh` to write a date-based version

## Testing
- `./update-version.sh`

------
https://chatgpt.com/codex/tasks/task_e_686751a0fb88832c90c6dd935cd070cc