### PR TITLE
Add crypto candlestick charts

### DIFF
--- a/crypto_prices.html
+++ b/crypto_prices.html
@@ -29,8 +29,15 @@
   <h1>BTC and ETH Prices (USD)</h1>
   <div class="price" id="btc-price">Loading BTC price...</div>
   <div class="price" id="eth-price">Loading ETH price...</div>
+  <h2 style="text-align:center;">BTC Candlestick Chart (30 Days)</h2>
+  <canvas id="btc-chart" width="600" height="300"></canvas>
+  <h2 style="text-align:center;">ETH Candlestick Chart (30 Days)</h2>
+  <canvas id="eth-chart" width="600" height="300"></canvas>
   <p style="text-align:center;"><a href="index.html">&#8592; Back to Home</a></p>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chartjs-chart-financial"></script>
   <script src="scripts/crypto_prices.js"></script>
+  <script src="scripts/crypto_candlestick.js"></script>
   <script src="scripts/keyboard_nav.js"></script>
   <script src="scripts/site_search.js"></script>
 </body>

--- a/scripts/crypto_candlestick.js
+++ b/scripts/crypto_candlestick.js
@@ -1,0 +1,37 @@
+// Fetch OHLC data for BTC and ETH and render candlestick charts using Chart.js
+// Requires chartjs-chart-financial plugin.
+
+document.addEventListener('DOMContentLoaded', function() {
+  const configs = [
+    {id: 'bitcoin', label: 'BTC', canvas: 'btc-chart'},
+    {id: 'ethereum', label: 'ETH', canvas: 'eth-chart'}
+  ];
+
+  configs.forEach(cfg => loadChart(cfg));
+});
+
+async function loadChart({id, label, canvas}) {
+  try {
+    const resp = await fetch(`https://api.coingecko.com/api/v3/coins/${id}/ohlc?vs_currency=usd&days=30`);
+    if (!resp.ok) throw new Error('Network response was not ok');
+    const json = await resp.json();
+    const data = json.map(d => ({x: d[0], o: d[1], h: d[2], l: d[3], c: d[4]}));
+    const ctx = document.getElementById(canvas).getContext('2d');
+    new Chart(ctx, {
+      type: 'candlestick',
+      data: {
+        datasets: [{ label, data }]
+      },
+      options: {
+        responsive: true,
+        scales: {
+          x: { type: 'time' }
+        }
+      }
+    });
+  } catch (err) {
+    console.error(err);
+    const container = document.getElementById(canvas).parentNode;
+    container.textContent = 'Failed to load chart';
+  }
+}

--- a/search_index.json
+++ b/search_index.json
@@ -277,7 +277,7 @@
   {
     "title": "Crypto Prices",
     "url": "crypto_prices.html",
-    "text": "Live BTC and ETH prices"
+    "text": "Live BTC and ETH prices with candlestick charts"
   },
   {
     "title": "My Network",


### PR DESCRIPTION
## Summary
- display BTC & ETH candlesticks using Chart.js plugin
- load OHLC data from Coingecko
- update search index entry for crypto page

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68679f234e2c832cb581ecde4059d4ca