### PR TITLE
Add election turnout visualizations

### DIFF
--- a/cool_visualizations.html
+++ b/cool_visualizations.html
@@ -50,6 +50,9 @@
             <div class="link-card">
                 <a href="family_tree.html">Family Tree Maker</a>
             </div>
+            <div class="link-card">
+                <a href="election_visualizations.html">Election Visualizations</a>
+            </div>
         </div>
     </div>
 </div>

--- a/election_visualizations.html
+++ b/election_visualizations.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Election Visualizations</title>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <style>
+    body {
+      background-color: #000;
+      color: #fff;
+      font-family: "Courier New", Courier, monospace;
+      margin: 40px;
+    }
+    canvas {
+      background-color: #111;
+      display: block;
+      margin: 20px auto;
+    }
+    .chart-container {
+      max-width: 600px;
+      margin: 0 auto 40px auto;
+    }
+  </style>
+</head>
+<body>
+  <h1>Election Participation Visualized</h1>
+  <p>These animations show how many eligible voters sat out the 2024 election, and how turnout differed between people who voted for Biden and Trump in 2020.</p>
+
+  <div class="chart-container">
+    <canvas id="turnoutChart" width="400" height="300" aria-label="Overall turnout"></canvas>
+  </div>
+
+  <div class="chart-container">
+    <canvas id="bidenChart" width="400" height="300" aria-label="Biden 2020 voter breakdown"></canvas>
+  </div>
+
+  <div class="chart-container">
+    <canvas id="trumpChart" width="400" height="300" aria-label="Trump 2020 voter breakdown"></canvas>
+  </div>
+
+  <p><a href="cool_visualizations.html">&larr; Back to Visualizations</a></p>
+
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <script src="scripts/election_visualizations.js"></script>
+  <script src="scripts/keyboard_nav.js"></script>
+  <script src="scripts/site_search.js"></script>
+</body>
+</html>

--- a/scripts/election_visualizations.js
+++ b/scripts/election_visualizations.js
@@ -1,0 +1,56 @@
+// Election turnout visualizations
+
+function createChart(ctx, labels, data, colors, title) {
+  return new Chart(ctx, {
+    type: 'doughnut',
+    data: {
+      labels,
+      datasets: [{
+        data,
+        backgroundColor: colors,
+      }]
+    },
+    options: {
+      responsive: true,
+      plugins: {
+        legend: {
+          position: 'bottom',
+          labels: { color: '#fff', font: { family: 'Courier New' } }
+        },
+        title: {
+          display: true,
+          text: title,
+          color: '#fff',
+          font: { size: 18, family: 'Courier New' }
+        }
+      },
+      animation: { duration: 1500 }
+    }
+  });
+}
+
+window.addEventListener('DOMContentLoaded', () => {
+  // Chart 1: overall turnout
+  const totalCtx = document.getElementById('turnoutChart').getContext('2d');
+  createChart(totalCtx,
+    ['Voted', 'Didn\'t Vote'],
+    [63, 37],
+    ['#4caf50', '#c0392b'],
+    '2024 Eligible Voters');
+
+  // Chart 2: Biden 2020 voter behavior in 2024
+  const bidenCtx = document.getElementById('bidenChart').getContext('2d');
+  createChart(bidenCtx,
+    ['Harris', 'Didn\'t Vote', 'Trump', 'Third Party'],
+    [79, 15, 5, 1],
+    ['#1e90ff', '#c0392b', '#f1c40f', '#7f8c8d'],
+    '2020 Biden Voters in 2024');
+
+  // Chart 3: Trump 2020 voter behavior in 2024
+  const trumpCtx = document.getElementById('trumpChart').getContext('2d');
+  createChart(trumpCtx,
+    ['Trump', 'Didn\'t Vote', 'Harris', 'Third Party'],
+    [85, 11, 3, 1],
+    ['#f1c40f', '#c0392b', '#1e90ff', '#7f8c8d'],
+    '2020 Trump Voters in 2024');
+});

--- a/scripts/version.js
+++ b/scripts/version.js
@@ -1,5 +1,5 @@
 // This file is automatically updated by the pre-commit hook
 window.APP_VERSION = {
-  commit: "20250707",
-  date: "2025-07-07"
+  commit: "20250719",
+  date: "2025-07-19"
 };

--- a/search_index.json
+++ b/search_index.json
@@ -323,5 +323,10 @@
     "title": "Tamil Flashcards Extended",
     "url": "tamil_extended.html",
     "text": "Extended set of Tamil flashcards."
+  },
+  {
+    "title": "Election Visualizations",
+    "url": "election_visualizations.html",
+    "text": "Charts on turnout and 2020 voter participation"
   }
 ]


### PR DESCRIPTION
## Summary
- add new animated charts on 2024 turnout and voter attrition
- link the new demo from the visualizations hub
- update search index
- bump version metadata

## Testing
- `bash update-version.sh`

------
https://chatgpt.com/codex/tasks/task_e_687bc2d09ae0832c891511fcaa187544