### PR TITLE
Add animated transit math statement

### DIFF
--- a/scripts/typed_message.js
+++ b/scripts/typed_message.js
@@ -1,0 +1,16 @@
+document.addEventListener('DOMContentLoaded', function() {
+  const text = "Public Transit trips take 2.5 times longer than driving in DC—the city's mathematical proof you're worth less than half a person if you're too poor, too disabled, too young, or too old to drive";
+  const target = document.getElementById('typed-message');
+  let index = 0;
+  const speed = 50; // ms per character
+
+  function typeNext() {
+    if (index < text.length) {
+      target.textContent += text.charAt(index);
+      index++;
+      setTimeout(typeNext, speed);
+    }
+  }
+
+  typeNext();
+});

--- a/scripts/version.js
+++ b/scripts/version.js
@@ -1,5 +1,5 @@
 // This file is automatically updated by the pre-commit hook
 window.APP_VERSION = {
-  commit: "20250720",
-  date: "2025-07-20"
+  commit: "20250722",
+  date: "2025-07-22"
 };

--- a/search_index.json
+++ b/search_index.json
@@ -333,5 +333,10 @@
     "title": "Interactive Election Turnout Analysis",
     "url": "election_turnout_interactive.html",
     "text": "Interactive React visualizations showing 2024 election non-participation, voter flow analysis from 2020 to 2024, and loyalty gap between Trump and Biden voters. Features animated charts on the couch winning the election, retention rates, and turnout disparities."
+  },
+  {
+    "title": "Transit Math",
+    "url": "transit_reveal.html",
+    "text": "Public Transit trips take 2.5 times longer than driving in DC—the city's proof you're worth less than half a person if you rely on transit."
   }
 ]

--- a/sitemap.html
+++ b/sitemap.html
@@ -67,6 +67,7 @@
         <a href="airport_code_quiz.html">Airport Code Quiz</a>
         <a href="nanoleaf_layout_assistant.html">Nanoleaf Layout Assistant</a>
         <a href="time_tax.html">Time Tax Calculator</a>
+        <a href="transit_reveal.html">Transit Math</a>
         <a href="math_sequences.html">Math Sequences</a>
         <a href="fibonacci_spiral.html">Fibonacci Spiral</a>
         <a href="pascal_triangle.html">Pascal's Triangle</a>

--- a/transit_reveal.html
+++ b/transit_reveal.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Transit Math - Karthik Balasubramanian</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <style>
+    body {
+      background-color: black;
+      color: white;
+      font-family: "Courier New", Courier, monospace;
+      margin: 40px;
+      line-height: 1.6;
+    }
+    h1 {
+      max-width: 800px;
+      margin: 0 auto;
+      text-align: center;
+      font-size: 1.5em;
+    }
+    #cursor {
+      animation: blink 0.8s steps(1) infinite;
+    }
+    @keyframes blink {
+      0%,50% { opacity: 1; }
+      50.01%,100% { opacity: 0; }
+    }
+  </style>
+</head>
+<body>
+  <h1><span id="typed-message"></span><span id="cursor">_</span></h1>
+  <p style="text-align:center;"><a href="index.html">Back to Home</a></p>
+
+  <script src="scripts/typed_message.js"></script>
+  <script src="scripts/keyboard_nav.js"></script>
+  <script src="scripts/site_search.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create a dedicated `transit_reveal.html` page for a dramatic typed message
- implement typing effect in new `scripts/typed_message.js`
- index the new page in `search_index.json`
- link it from `sitemap.html`
- update autogenerated version

## Testing
- `./update-version.sh`

------
https://chatgpt.com/codex/tasks/task_e_688014148df0832c8f9476e24538d3bd